### PR TITLE
Execution monitoring with the expected atoms check

### DIFF
--- a/predicators/approaches/bilevel_planning_approach.py
+++ b/predicators/approaches/bilevel_planning_approach.py
@@ -48,6 +48,7 @@ class BilevelPlanningApproach(BaseApproach):
         self._num_calls = 0
         self._last_plan: List[_Option] = []  # used if plan WITH sim
         self._last_nsrt_plan: List[_GroundNSRT] = []  # plan WITHOUT sim
+        self._last_atoms_seq: List[Set[GroundAtom]]  # plan WITHOUT sim
 
     def _solve(self, task: Task, timeout: int) -> Callable[[State], Action]:
         self._num_calls += 1
@@ -59,9 +60,10 @@ class BilevelPlanningApproach(BaseApproach):
         # Run task planning only and then greedily sample and execute in the
         # policy.
         if self._plan_without_sim:
-            nsrt_plan, _, metrics = self._run_task_plan(
+            nsrt_plan, atoms_seq, metrics = self._run_task_plan(
                 task, nsrts, preds, timeout, seed)
             self._last_nsrt_plan = nsrt_plan
+            self._last_atoms_seq = atoms_seq
             policy = utils.nsrt_plan_to_greedy_policy(nsrt_plan, task.goal,
                                                       self._rng)
 
@@ -239,3 +241,19 @@ class BilevelPlanningApproach(BaseApproach):
         """
         assert self.get_name() == "oracle"
         return self._last_nsrt_plan
+
+    def get_last_atoms_seq(self) -> List[Set[GroundAtom]]:
+        """Similar to get_last_plan() in that only oracle should use this.
+
+        And this will only be used when bilevel_plan_without_sim is
+        True.
+        """
+        assert self.get_name() == "oracle"
+        assert self._plan_without_sim
+        return self._last_atoms_seq
+
+    def get_execution_monitoring_info(self) -> List[Set[GroundAtom]]:
+        if self._plan_without_sim:
+            return self.get_last_atoms_seq()
+        else:
+            return []

--- a/predicators/approaches/bilevel_planning_approach.py
+++ b/predicators/approaches/bilevel_planning_approach.py
@@ -255,5 +255,4 @@ class BilevelPlanningApproach(BaseApproach):
     def get_execution_monitoring_info(self) -> List[Set[GroundAtom]]:
         if self._plan_without_sim:
             return self.get_last_atoms_seq()
-        else:
-            return []
+        return []

--- a/predicators/execution_monitoring/base_execution_monitor.py
+++ b/predicators/execution_monitoring/base_execution_monitor.py
@@ -9,7 +9,7 @@ from predicators.structs import State, Task
 class BaseExecutionMonitor(abc.ABC):
     """An execution monitor consumes states and decides whether to replan."""
 
-    def __init__(self):
+    def __init__(self) -> None:
         self._approach_info: List[Any] = []
 
     @classmethod

--- a/predicators/execution_monitoring/expected_atoms_monitor.py
+++ b/predicators/execution_monitoring/expected_atoms_monitor.py
@@ -1,0 +1,42 @@
+"""An execution monitor that leverages knowledge of the high-level plan to only
+suggest replanning when the expected atoms check is not met."""
+
+from typing import Set
+
+from predicators import utils
+from predicators.envs import get_or_create_env
+from predicators.execution_monitoring.base_execution_monitor import \
+    BaseExecutionMonitor
+from predicators.settings import CFG
+from predicators.structs import State, Task
+
+
+class ExpectedAtomsExecutionMonitor(BaseExecutionMonitor):
+    """An execution monitor that only suggests replanning when we're doing
+    bilevel planning and the expected atoms check fails."""
+
+    def __init__(self) -> None:
+        super().__init__()
+        self._curr_plan_timestep = 0
+
+    @classmethod
+    def get_name(cls) -> str:
+        return "expected_atoms"
+
+    def reset(self, task: Task) -> None:
+        self._curr_plan_timestep = 0
+
+    def step(self, state: State) -> bool:
+        # This monitor only makes sense to use with an oracle
+        # bilevel planning approach.
+        assert CFG.approach == "oracle"
+        assert len(self._approach_info) > self._curr_plan_timestep
+        assert isinstance(self._approach_info[0], Set)
+        curr_env = get_or_create_env(CFG.env)
+        predicates = curr_env.predicates
+        curr_atoms = utils.abstract(state, predicates)
+        # If the expected atoms are a subset of the current atoms, then
+        # we don't have to replan.
+        if self._approach_info[self._curr_plan_timestep].issubset(curr_atoms):
+            return False
+        return True

--- a/tests/execution_monitoring/test_execution_monitoring.py
+++ b/tests/execution_monitoring/test_execution_monitoring.py
@@ -3,6 +3,8 @@
 import pytest
 
 from predicators.execution_monitoring import create_execution_monitor
+from predicators.execution_monitoring.expected_atoms_monitor import \
+    ExpectedAtomsExecutionMonitor
 from predicators.execution_monitoring.mpc_execution_monitor import \
     MpcExecutionMonitor
 from predicators.execution_monitoring.trivial_execution_monitor import \
@@ -16,6 +18,9 @@ def test_create_execution_monitor():
 
     exec_monitor = create_execution_monitor("mpc")
     assert isinstance(exec_monitor, MpcExecutionMonitor)
+
+    exec_monitor = create_execution_monitor("expected_atoms")
+    assert isinstance(exec_monitor, ExpectedAtomsExecutionMonitor)
 
     with pytest.raises(NotImplementedError) as e:
         create_execution_monitor("not a real monitor")

--- a/tests/test_cogman.py
+++ b/tests/test_cogman.py
@@ -40,3 +40,35 @@ def test_cogman(exec_monitor_name):
     next_obs = env.step(act)
     next_act = cogman.step(next_obs)
     assert not np.allclose(act.arr, next_act.arr)
+
+
+def test_cogman_with_expected_atoms_monitor():
+    """Tests for CogMan() with bilevel planning and the 'expected_atoms'
+    execution monitor."""
+    env_name = "cover"
+    utils.reset_config({
+        "env": env_name,
+        "num_train_tasks": 0,
+        "num_test_tasks": 2,
+        "bilevel_plan_without_sim": True,
+        "approach": "oracle"
+    })
+    env = get_or_create_env(env_name)
+    env_train_tasks = env.get_train_tasks()
+    env_test_tasks = env.get_test_tasks()
+    train_tasks = [t.task for t in env_train_tasks]
+    options = get_gt_options(env.get_name())
+    perceiver = create_perceiver("trivial")
+    exec_monitor = create_execution_monitor("expected_atoms")
+    approach = create_approach("oracle", env.predicates, options, env.types,
+                               env.action_space, train_tasks)
+    cogman = CogMan(approach, perceiver, exec_monitor)
+    env.reset("test", 0)
+    env_task = env_test_tasks[0]
+    cogman.reset(env_task)
+    obs = env_task.init_obs
+    act = cogman.step(obs)
+    assert env.action_space.contains(act.arr)
+    next_obs = env.step(act)
+    next_act = cogman.step(next_obs)
+    assert not np.allclose(act.arr, next_act.arr)


### PR DESCRIPTION
This PR implements functionality for monitoring execution of a plan made without a simulator. Specifically, the idea is that we just do task planning, then directly execute. BUT! after every NSRT execution, we check that the expected atoms check holds and give the signal to replan otherwise.

Intended usage example:
```
python predicators/main.py --env spot_bike_env --approach oracle --seed 0 --num_test_tasks 1 --sesame_task_planner fdopt --bilevel_plan_without_sim True --execution_monitor expected_atoms
```