### PR TITLE
Added ids from Apriltag to use during Grasping

### DIFF
--- a/predicators/spot_utils/spot_utils.py
+++ b/predicators/spot_utils/spot_utils.py
@@ -63,6 +63,13 @@ graph_nav_loc_to_id = {
     "trash": "holy-aphid-SuqZLSjvRUjUxCDywLIFhw=="
 }
 
+obj_name_to_apriltag_id = {
+    "hammer": "401",
+    "brush": "402",
+    "hex_key": "403",
+    "hex_screwdriver": "404"
+}
+
 
 # pylint: disable=no-member
 class _SpotInterface():
@@ -220,7 +227,7 @@ class _SpotInterface():
         elif params[3] == -1:
             self._force_horizontal_grasp = True
             self._force_top_down_grasp = False
-        self.arm_object_grasp()
+        self.arm_object_grasp(objs[1])
         if not all(params[:3] == [0.0, 0.0, 0.0]):
             self.hand_movement(params[:3], open_gripper=False)
         self.stow_arm()
@@ -364,7 +371,7 @@ class _SpotInterface():
 
         return grasp
 
-    def arm_object_grasp(self) -> None:
+    def arm_object_grasp(self, obj: Object) -> None:
         """A simple example of using the Boston Dynamics API to command Spot's
         arm."""
         assert self.robot.is_powered_on(), "Robot power on failed."
@@ -372,6 +379,7 @@ class _SpotInterface():
 
         # Take a picture with a camera
         self.robot.logger.info(f'Getting an image from: {self._image_source}')
+        time.sleep(1)
         image_responses = self.image_client.get_image_from_sources(
             [self._image_source])
 
@@ -408,17 +416,14 @@ class _SpotInterface():
             gray = cv2.cvtColor(img, cv2.COLOR_BGR2GRAY)
 
             # Define the AprilTags detector options and then detect the tags.
-            self.robot.logger("[INFO] detecting AprilTags...")
+            self.robot.logger.info("[INFO] detecting AprilTags...")
             options = apriltag.DetectorOptions(families="tag36h11")
             detector = apriltag.Detector(options)
             results = detector.detect(gray)
-            self.robot.logger(f"[INFO] {len(results)} AprilTags detected")
-
-            # Make center of first Apriltag found as grasp location.
-            # If None are found grasp will remain None and default to click
-            # based grasping.
-            if len(results) > 0:
-                g_image_click = results[0].center
+            self.robot.logger.info(f"[INFO] {len(results)} AprilTags detected")
+            for result in results:
+                if str(result.tag_id) == obj_name_to_apriltag_id[obj.name]:
+                    g_image_click = results[0].center
 
         while g_image_click is None:
             key = cv2.waitKey(1) & 0xFF


### PR DESCRIPTION
This PR allows for grasping multiple object with Apriltags. It uses a dictionary `obj_name_to_apriltag_id` that matches objects with ids and then grasps the apriltag_id that corresponds with obj in the controller.