### PR TITLE
Create new perceiver to implement Holding predicate for `SpotBikeEnv`

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -2,6 +2,7 @@
 omit =
     predicators/third_party/**
     predicators/spot_utils/**
+    predicators/perception/spot_bike_perceiver.py
 
 [report]
 # Regexes for lines to exclude from consideration

--- a/predicators/cogman.py
+++ b/predicators/cogman.py
@@ -53,6 +53,7 @@ class CogMan:
             assert not self._exec_monitor.step(state)
         assert self._current_policy is not None
         act = self._current_policy(state)
+        self._perceiver.update_perceiver_with_action(act)
         return act
 
     # The methods below provide an interface to the approach. In the future,

--- a/predicators/envs/spot_env.py
+++ b/predicators/envs/spot_env.py
@@ -258,7 +258,6 @@ class SpotEnv(BaseEnv):
             return None
         # Apply the operator.
         next_ground_atoms = utils.apply_operator(ground_op, ground_atoms)
-
         # Return only the atoms for the non-continuous-feature predicates.
         return {
             a

--- a/predicators/envs/spot_env.py
+++ b/predicators/envs/spot_env.py
@@ -132,8 +132,11 @@ class SpotEnv(BaseEnv):
         ub_arr = np.array(ub, dtype=np.float32)
         return Box(lb_arr, ub_arr, dtype=np.float32)
 
-    def _parse_action(self, state: State,
+    def parse_action(self, state: State,
                       action: Action) -> Tuple[str, List[Object], Array]:
+        """(Only for this environment) A convenience method that converts
+        low-level actions into more interpretable high-level actions by
+        exploiting knowledge of how we encode actions."""
         # Convert the first action part into a _GroundSTRIPSOperator.
         first_action_part_len = self._max_operator_arity + 1
         op_action = Action(action.arr[:first_action_part_len])
@@ -197,7 +200,7 @@ class SpotEnv(BaseEnv):
         assert isinstance(state, _PartialPerceptionState)
         assert self.action_space.contains(action.arr)
         # Parse the action into the components needed for a controller.
-        name, objects, params = self._parse_action(state, action)
+        name, objects, params = self.parse_action(state, action)
         # Execute the controller in the real environment.
         current_atoms = utils.abstract(state, self.predicates)
         self._spot_interface.execute(name, current_atoms, objects, params)

--- a/predicators/envs/spot_env.py
+++ b/predicators/envs/spot_env.py
@@ -259,15 +259,6 @@ class SpotEnv(BaseEnv):
         # Apply the operator.
         next_ground_atoms = utils.apply_operator(ground_op, ground_atoms)
 
-        # HACK! We put back in the delete effects so that if the execution
-        # monitor ever returns that we should replan, then we will not hit
-        # dr-reachable errors. We should remove this once we have actual
-        # predicate functions implemented for all our predicates.
-        if CFG.execution_monitor == "expected_atoms":
-            # TODO: this crosses the line into do-not-merge, but let's see
-            # if it works.
-            next_ground_atoms |= {a for a in ground_op.delete_effects if "Reachable" not in str(a)}
-
         # Return only the atoms for the non-continuous-feature predicates.
         return {
             a
@@ -891,8 +882,9 @@ class SpotBikeEnv(SpotEnv):
         spot, obj_to_grasp = objects
         assert obj_name_to_apriltag_id.get(obj_to_grasp.name) is not None
         spot_holding_obj_id = state.get(spot, "curr_held_item_id")
-        return int(spot_holding_obj_id) == int(
-            obj_name_to_apriltag_id[obj_to_grasp.name]) and self._nothandempty_classifier(state, [spot])
+        return int(spot_holding_obj_id) == int(obj_name_to_apriltag_id[
+            obj_to_grasp.name]) and self._nothandempty_classifier(
+                state, [spot])
 
     @classmethod
     def get_name(cls) -> str:
@@ -912,12 +904,12 @@ class SpotBikeEnv(SpotEnv):
         spot = curr_state.get_objects(self._robot_type)[0]
         curr_state.set(spot, "gripper_open_percentage", new_gripper_open_perc)
         return curr_state
-    
-    def update_observation(self, updated_obs: Observation) -> None: # pragma: no cover
-        """Necessary so that the perceiver can update the environment's
-        current state."""
-        self._current_observation = updated_obs
 
+    def update_observation(
+            self, updated_obs: Observation) -> None:  # pragma: no cover
+        """Necessary so that the perceiver can update the environment's current
+        state."""
+        self._current_observation = updated_obs
 
     def _generate_tasks(self, num_tasks: int) -> List[EnvironmentTask]:
         tasks: List[EnvironmentTask] = []

--- a/predicators/envs/spot_env.py
+++ b/predicators/envs/spot_env.py
@@ -14,7 +14,8 @@ from predicators import utils
 from predicators.envs import BaseEnv
 from predicators.envs.pddl_env import _action_to_ground_strips_op
 from predicators.settings import CFG
-from predicators.spot_utils.spot_utils import get_spot_interface, obj_name_to_apriltag_id
+from predicators.spot_utils.spot_utils import get_spot_interface, \
+    obj_name_to_apriltag_id
 from predicators.structs import Action, Array, EnvironmentTask, GroundAtom, \
     LiftedAtom, Object, Observation, Predicate, State, STRIPSOperator, Type, \
     Variable

--- a/predicators/envs/spot_env.py
+++ b/predicators/envs/spot_env.py
@@ -264,7 +264,9 @@ class SpotEnv(BaseEnv):
         # dr-reachable errors. We should remove this once we have actual
         # predicate functions implemented for all our predicates.
         if CFG.execution_monitor == "expected_atoms":
-            next_ground_atoms |= ground_op.delete_effects
+            # TODO: this crosses the line into do-not-merge, but let's see
+            # if it works.
+            next_ground_atoms |= {a for a in ground_op.delete_effects if "Reachable" not in str(a)}
 
         # Return only the atoms for the non-continuous-feature predicates.
         return {
@@ -712,7 +714,8 @@ class SpotBikeEnv(SpotEnv):
         }
         del_effs = {
             LiftedAtom(self._On, [tool, surface]),
-            LiftedAtom(self._HandEmpty, [spot])
+            LiftedAtom(self._HandEmpty, [spot]),
+            LiftedAtom(self._ReachableTool, [spot, tool]),
         }
         self._GraspToolFromNotHighOp = STRIPSOperator("GraspToolFromNotHigh",
                                                       [spot, tool, surface],
@@ -729,7 +732,10 @@ class SpotBikeEnv(SpotEnv):
             LiftedAtom(self._HoldingPlatformLeash, [spot, platform]),
             LiftedAtom(self._notHandEmpty, [spot])
         }
-        del_effs = {LiftedAtom(self._HandEmpty, [spot])}
+        del_effs = {
+            LiftedAtom(self._HandEmpty, [spot]),
+            LiftedAtom(self._ReachablePlatform, [spot, platform]),
+        }
         self._GraspPlatformLeashOp = STRIPSOperator("GraspPlatformLeash",
                                                     [spot, platform], preconds,
                                                     add_effs, del_effs, set())
@@ -771,7 +777,8 @@ class SpotBikeEnv(SpotEnv):
         }
         del_effs = {
             LiftedAtom(self._On, [tool, surface]),
-            LiftedAtom(self._HandEmpty, [spot])
+            LiftedAtom(self._HandEmpty, [spot]),
+            LiftedAtom(self._ReachableTool, [spot, tool]),
         }
         self._GraspToolFromHighOp = STRIPSOperator(
             "GraspToolFromHigh", [spot, tool, platform, surface], preconds,
@@ -785,9 +792,12 @@ class SpotBikeEnv(SpotEnv):
         }
         add_effs = {
             LiftedAtom(self._HoldingBag, [spot, bag]),
-            LiftedAtom(self._notHandEmpty, [spot])
+            LiftedAtom(self._notHandEmpty, [spot]),
         }
-        del_effs = {LiftedAtom(self._HandEmpty, [spot])}
+        del_effs = {
+            LiftedAtom(self._HandEmpty, [spot]),
+            LiftedAtom(self._ReachableBag, [spot, bag]),
+        }
         self._GraspBagOp = STRIPSOperator("GraspBag", [spot, bag], preconds,
                                           add_effs, del_effs, set())
         # PlaceToolOnNotHighSurface
@@ -806,7 +816,8 @@ class SpotBikeEnv(SpotEnv):
         }
         del_effs = {
             LiftedAtom(self._HoldingTool, [spot, tool]),
-            LiftedAtom(self._notHandEmpty, [spot])
+            LiftedAtom(self._notHandEmpty, [spot]),
+            LiftedAtom(self._XYReachableSurface, [spot, surface]),
         }
         self._PlaceToolNotHighOp = STRIPSOperator("PlaceToolNotHigh",
                                                   [spot, tool, surface],
@@ -827,7 +838,8 @@ class SpotBikeEnv(SpotEnv):
         }
         del_effs = {
             LiftedAtom(self._HoldingTool, [spot, tool]),
-            LiftedAtom(self._notHandEmpty, [spot])
+            LiftedAtom(self._notHandEmpty, [spot]),
+            LiftedAtom(self._ReachableBag, [spot, bag]),
         }
         self._PlaceIntoBagOp = STRIPSOperator("PlaceIntoBag",
                                               [spot, tool, bag], preconds,

--- a/predicators/envs/spot_env.py
+++ b/predicators/envs/spot_env.py
@@ -256,9 +256,11 @@ class SpotEnv(BaseEnv):
         # We need to remove any "HoldingTool" atoms from the preconditions
         # because of current perception stuff. Note that this is a hack and
         # we should DEFINITELY remove this in the future.
-        preconditions_to_check = set(
-            atom for atom in ground_op.preconditions
-            if "HoldingTool" not in atom.predicate.name)
+        preconditions_to_check = set()
+        if ground_op is not None:
+            preconditions_to_check = set(
+                atom for atom in ground_op.preconditions
+                if "HoldingTool" not in atom.predicate.name)
 
         # If the operator is not applicable in this state, noop.
         if ground_op is None or not preconditions_to_check.issubset(

--- a/predicators/perception/base_perceiver.py
+++ b/predicators/perception/base_perceiver.py
@@ -2,7 +2,7 @@
 
 import abc
 
-from predicators.structs import EnvironmentTask, Observation, State, Task
+from predicators.structs import EnvironmentTask, Observation, State, Task, Action
 
 
 class BasePerceiver(abc.ABC):
@@ -20,3 +20,10 @@ class BasePerceiver(abc.ABC):
     @abc.abstractmethod
     def step(self, observation: Observation) -> State:
         """Produce a State given the current and past observations."""
+
+    def update_perceiver_with_action(self, action: Action) -> None:
+        """In some cases, the perceiver might need to know the
+        action that was taken (e.g. if the agent is trying
+        to grasp an object, the perceiver needs to know which
+        object this is)."""
+        pass

--- a/predicators/perception/base_perceiver.py
+++ b/predicators/perception/base_perceiver.py
@@ -26,4 +26,3 @@ class BasePerceiver(abc.ABC):
         """In some cases, the perceiver might need to know the action that was
         taken (e.g. if the agent is trying to grasp an object, the perceiver
         needs to know which object this is)."""
-        pass

--- a/predicators/perception/base_perceiver.py
+++ b/predicators/perception/base_perceiver.py
@@ -2,7 +2,8 @@
 
 import abc
 
-from predicators.structs import EnvironmentTask, Observation, State, Task, Action
+from predicators.structs import Action, EnvironmentTask, Observation, State, \
+    Task
 
 
 class BasePerceiver(abc.ABC):
@@ -22,8 +23,7 @@ class BasePerceiver(abc.ABC):
         """Produce a State given the current and past observations."""
 
     def update_perceiver_with_action(self, action: Action) -> None:
-        """In some cases, the perceiver might need to know the
-        action that was taken (e.g. if the agent is trying
-        to grasp an object, the perceiver needs to know which
-        object this is)."""
+        """In some cases, the perceiver might need to know the action that was
+        taken (e.g. if the agent is trying to grasp an object, the perceiver
+        needs to know which object this is)."""
         pass

--- a/predicators/perception/spot_bike_perceiver.py
+++ b/predicators/perception/spot_bike_perceiver.py
@@ -57,9 +57,7 @@ class SpotBikePerceiver(BasePerceiver):
                 robot_object = objects[0]
                 observation.set(robot_object, "curr_held_item_id",
                                 grasp_obj_id)
-                self._curr_env.update_observation(observation)
             elif "place" in controller_name.lower():
                 robot_object = objects[0]
                 observation.set(robot_object, "curr_held_item_id", 0.0)
-                self._curr_env.update_observation(observation)
         return observation

--- a/predicators/perception/spot_bike_perceiver.py
+++ b/predicators/perception/spot_bike_perceiver.py
@@ -10,12 +10,9 @@ from predicators.spot_utils.spot_utils import obj_name_to_apriltag_id
 from predicators.structs import Action, EnvironmentTask, Object, Observation, \
     State, Task
 
-# Each observation is a tuple of four 2D boolean masks (numpy arrays).
-# The order is: free, goals, boxes, player.
-
 
 class SpotBikePerceiver(BasePerceiver):
-    """A spot-bike-env-specific perceiver."""
+    """A perceiver specific to the spot bike env."""
 
     def __init__(self) -> None:
         super().__init__()

--- a/predicators/perception/spot_bike_perceiver.py
+++ b/predicators/perception/spot_bike_perceiver.py
@@ -1,16 +1,16 @@
 """A sokoban-specific perceiver."""
 
-from typing import Dict, Tuple, Set, List
+from typing import Dict, List, Set, Tuple
 
 import numpy as np
 
-from predicators.settings import CFG
-from predicators.envs.spot_env import _PartialPerceptionState, SpotBikeEnv
-from predicators.perception.base_perceiver import BasePerceiver
-from predicators.structs import EnvironmentTask, GroundAtom, Object, \
-    Observation, State, Task, Action
-from predicators.spot_utils.spot_utils import obj_name_to_apriltag_id
 from predicators.envs import get_or_create_env
+from predicators.envs.spot_env import SpotBikeEnv, _PartialPerceptionState
+from predicators.perception.base_perceiver import BasePerceiver
+from predicators.settings import CFG
+from predicators.spot_utils.spot_utils import obj_name_to_apriltag_id
+from predicators.structs import Action, EnvironmentTask, GroundAtom, Object, \
+    Observation, State, Task
 
 # Each observation is a tuple of four 2D boolean masks (numpy arrays).
 # The order is: free, goals, boxes, player.

--- a/predicators/perception/spot_bike_perceiver.py
+++ b/predicators/perception/spot_bike_perceiver.py
@@ -1,0 +1,65 @@
+"""A sokoban-specific perceiver."""
+
+from typing import Dict, Tuple, Set, List
+
+import numpy as np
+
+from predicators.settings import CFG
+from predicators.envs.spot_env import _PartialPerceptionState, SpotBikeEnv
+from predicators.perception.base_perceiver import BasePerceiver
+from predicators.structs import EnvironmentTask, GroundAtom, Object, \
+    Observation, State, Task, Action
+from predicators.spot_utils.spot_utils import obj_name_to_apriltag_id
+from predicators.envs import get_or_create_env
+
+# Each observation is a tuple of four 2D boolean masks (numpy arrays).
+# The order is: free, goals, boxes, player.
+
+
+class SpotBikePerceiver(BasePerceiver):
+    """A spot-bike-env-specific perceiver."""
+
+    def __init__(self) -> None:
+        super().__init__()
+        self._prev_action: Action = None
+        self._object_attempting_to_be_grasped: Object = None
+        self._curr_task_objects: Set[Object] = set()
+        assert CFG.env == "spot_bike_env"
+        self._curr_env: SpotBikeEnv = None
+
+    @classmethod
+    def get_name(cls) -> str:
+        return "spot_bike_env"
+
+    def reset(self, env_task: EnvironmentTask) -> Task:
+        self._prev_action = None
+        self._curr_task_objects = set(env_task.init.data)
+        # We currently have hardcoded logic that expects
+        # certain items to be in the state; we can generalize
+        # this later.
+        assert set("hex_key", "hammer", "hex_screwdriver",
+                   "brush").issubset(obj.name
+                                     for obj in self._curr_task_objects)
+        self._curr_env = get_or_create_env("spot_bike_env")
+        assert isinstance(self._curr_env, SpotBikeEnv)
+        return env_task.task
+
+    def update_perceiver_with_action(self, action: Action) -> None:
+        self._prev_action = action
+
+    def step(self, observation: Observation) -> State:
+        assert isinstance(observation, _PartialPerceptionState)
+        if self._prev_action is not None:
+            assert self._curr_env is not None
+            controller_name, objects, _ = self._curr_env._parse_action(
+                observation, self._prev_action)
+            if "grasp" in controller_name.lower():
+                # We know that the object that we attempted to grasp was
+                # the second argument to the controller.
+                object_attempted_to_grasp = objects[1].name
+                grasp_obj_id = obj_name_to_apriltag_id[
+                    object_attempted_to_grasp]
+                robot_object = objects[0]
+                observation.set(robot_object, "curr_held_item_id",
+                                grasp_obj_id)
+        return observation

--- a/predicators/perception/spot_bike_perceiver.py
+++ b/predicators/perception/spot_bike_perceiver.py
@@ -1,4 +1,4 @@
-"""A sokoban-specific perceiver."""
+"""A perceiver specific to the spot bike env."""
 
 from typing import Optional, Set
 

--- a/predicators/spot_utils/spot_utils.py
+++ b/predicators/spot_utils/spot_utils.py
@@ -384,6 +384,9 @@ class _SpotInterface():
 
         self.navigate_to(waypoint_id, params)
         self.stow_arm()
+        # NOTE: time.sleep(2.0) required afer each option execution
+        # to allow time for sensor readings to settle.
+        time.sleep(2.0)
 
     def graspController(self, objs: Sequence[Object], params: Array) -> None:
         """Wrapper method for grasp controller.
@@ -405,6 +408,9 @@ class _SpotInterface():
         if not all(params[:3] == [0.0, 0.0, 0.0]):
             self.hand_movement(params[:3], open_gripper=False)
         self.stow_arm()
+        # NOTE: time.sleep(2.0) required afer each option execution
+        # to allow time for sensor readings to settle.
+        time.sleep(2.0)
 
     def placeOntopController(self, objs: Sequence[Object],
                              params: Array) -> None:
@@ -418,6 +424,9 @@ class _SpotInterface():
         self.hand_movement(params, keep_hand_pose=False)
         time.sleep(1.0)
         self.stow_arm()
+        # NOTE: time.sleep(2.0) required afer each option execution
+        # to allow time for sensor readings to settle.
+        time.sleep(2.0)
 
     def verify_estop(self, robot: Any) -> None:
         """Verify the robot is not estopped."""
@@ -697,7 +706,7 @@ class _SpotInterface():
             stow_and_close_command)
         self.robot.logger.info("Stow command issued.")
         block_until_arm_arrives(self.robot_command_client,
-                                stow_and_close_command_id, 3.0)
+                                stow_and_close_command_id, 4.5)
 
     def hand_movement(self,
                       params: Array,

--- a/predicators/spot_utils/spot_utils.py
+++ b/predicators/spot_utils/spot_utils.py
@@ -589,7 +589,7 @@ class _SpotInterface():
             results = detector.detect(gray)
             self.robot.logger.info(f"[INFO] {len(results)} AprilTags detected")
             for result in results:
-                if str(result.tag_id) == obj_name_to_apriltag_id[obj.name]:
+                if result.tag_id == obj_name_to_apriltag_id[obj.name]:
                     g_image_click = results[0].center
 
         elif CFG.spot_grasp_use_cv2:

--- a/predicators/structs.py
+++ b/predicators/structs.py
@@ -113,11 +113,7 @@ class State:
     def __post_init__(self) -> None:
         # Check feature vector dimensions.
         for obj in self:
-            try:
-                assert len(self[obj]) == obj.type.dim
-            except AssertionError:
-                import ipdb
-                ipdb.set_trace()
+            assert len(self[obj]) == obj.type.dim
 
     def __iter__(self) -> Iterator[Object]:
         """An iterator over the state's objects, in sorted order."""

--- a/tests/envs/test_spot_envs.py
+++ b/tests/envs/test_spot_envs.py
@@ -81,7 +81,7 @@ def test_spot_env_oracle_nsrts():
     ground_option = ground_nsrt.sample_option(state, set(), rng)
     act = ground_option.policy(state)
     assert env.action_space.contains(act.arr)
-    name, objs, params = env._parse_action(state, act)  # pylint:disable=protected-access
+    name, objs, params = env.parse_action(state, act)
     assert name == "navigate"
     assert objs == [spot, counter]
     assert np.allclose(params, ground_option.params)
@@ -93,7 +93,7 @@ def test_spot_env_oracle_nsrts():
     ground_option = ground_nsrt.sample_option(state, set(), rng)
     act = ground_option.policy(state)
     assert env.action_space.contains(act.arr)
-    name, objs, params = env._parse_action(state, act)  # pylint:disable=protected-access
+    name, objs, params = env.parse_action(state, act)
     assert name == "navigate"
     assert objs == [spot, soda_can]
     assert np.allclose(params, ground_option.params)
@@ -102,7 +102,7 @@ def test_spot_env_oracle_nsrts():
     ground_option = ground_nsrt.sample_option(state, set(), rng)
     act = ground_option.policy(state)
     assert env.action_space.contains(act.arr)
-    name, objs, params = env._parse_action(state, act)  # pylint:disable=protected-access
+    name, objs, params = env.parse_action(state, act)
     assert name == "grasp"
     assert objs == [spot, soda_can, counter]
     assert np.allclose(params, ground_option.params)
@@ -111,7 +111,7 @@ def test_spot_env_oracle_nsrts():
     ground_option = ground_nsrt.sample_option(state, set(), rng)
     act = ground_option.policy(state)
     assert env.action_space.contains(act.arr)
-    name, objs, params = env._parse_action(state, act)  # pylint:disable=protected-access
+    name, objs, params = env.parse_action(state, act)
     assert name == "placeOnTop"
     assert objs == [spot, soda_can, counter]
     assert np.allclose(params, ground_option.params)


### PR DESCRIPTION
This PR creates a new `Perceiver` specific to the `SpotBikeEnv`. The main reason for this is so that we can implement a `Holding` predicate.

The new perceiver works by effectively 'remembering' what object we tried to pick up before grasping, and then asserting a property in the low-level state-space that says that this object was picked up.

Note that using the expected atoms check with this doesn't lead to desired behavior (the robot thinks On is made false by grasping, and then we end up in a dead end state :/) because we need a classifier for `On` and `Reachable`, which will be implemented in forthcoming PR's.

Example command:
```
python predicators/main.py --env spot_bike_env --approach oracle --seed 0 --num_train_tasks 0 --num_test_tasks 1 --spot_robot_ip <spot-ip> --bilevel_plan_without_sim True --spot_grasp_use_apriltag True --perceiver spot_bike_env --execution_monitor expected_atoms
```