### PR TITLE
use all cameras to construct initial state

### DIFF
--- a/predicators/spot_utils/spot_utils.py
+++ b/predicators/spot_utils/spot_utils.py
@@ -101,11 +101,10 @@ OBJECT_GRASP_OFFSET = {
 
 COMMAND_TIMEOUT = 20.0
 
-CAMERA_NAMES = ["hand_color_image", "left_fisheye_image", "back_fisheye_image"]
-
-
-# TODO remove
-DEBUG_COUNT = 0
+CAMERA_NAMES = [
+    "hand_color_image", "left_fisheye_image", "right_fisheye_image",
+    "frontleft_fisheye_image", "frontright_fisheye_image", "back_fisheye_image"
+]
 
 
 def _find_object_center(img: Image,
@@ -351,11 +350,6 @@ class _SpotInterface():
         """
         img, image_response = self.get_single_camera_image(source_name)
 
-        global DEBUG_COUNT
-        import imageio
-        imageio.imwrite(f"debug_images/{source_name}_{DEBUG_COUNT}.png", img)
-        DEBUG_COUNT += 1
-
         # Camera body transform.
         camera_tform_body = get_a_tform_b(
             image_response[0].shot.transforms_snapshot,
@@ -364,9 +358,8 @@ class _SpotInterface():
         # Camera intrinsics for the given source camera.
         intrinsics = image_response[0].source.pinhole.intrinsics
 
-        # Rotate each image such that it is upright and make it gray.
-        image_grey = cv2.cvtColor(self.rotate_image(img, source_name),
-                                  cv2.COLOR_BGR2GRAY)
+        # Convert the image to grayscale.
+        image_grey = cv2.cvtColor(img, cv2.COLOR_BGR2GRAY)
 
         # Create apriltag detector and get all apriltag locations.
         options = apriltag.DetectorOptions(families="tag36h11")
@@ -408,17 +401,6 @@ class _SpotInterface():
                 obj_poses[detection.tag_id] = fiducial_rt_gn_origin
 
         return obj_poses
-
-    @staticmethod
-    def rotate_image(image: Image, source_name: str) -> Image:
-        """Rotate the image so that it is always displayed upright."""
-        if source_name == "frontleft_fisheye_image":
-            image = cv2.rotate(image, rotateCode=0)
-        elif source_name == "right_fisheye_image":
-            image = cv2.rotate(image, rotateCode=1)
-        elif source_name == "frontright_fisheye_image":
-            image = cv2.rotate(image, rotateCode=0)
-        return image
 
     def get_gripper_obs(self) -> float:
         """Grabs the current observation of relevant quantities from the

--- a/predicators/spot_utils/spot_utils.py
+++ b/predicators/spot_utils/spot_utils.py
@@ -104,6 +104,10 @@ COMMAND_TIMEOUT = 20.0
 CAMERA_NAMES = ["hand_color_image", "left_fisheye_image", "back_fisheye_image"]
 
 
+# TODO remove
+DEBUG_COUNT = 0
+
+
 def _find_object_center(img: Image,
                         obj_name: str) -> Optional[Tuple[int, int]]:
     # Copy to make sure we don't modify the image.
@@ -346,6 +350,11 @@ class _SpotInterface():
         position tuple in the map frame.
         """
         img, image_response = self.get_single_camera_image(source_name)
+
+        global DEBUG_COUNT
+        import imageio
+        imageio.imwrite(f"debug_images/{source_name}_{DEBUG_COUNT}.png", img)
+        DEBUG_COUNT += 1
 
         # Camera body transform.
         camera_tform_body = get_a_tform_b(


### PR DESCRIPTION
fix bug where we were rotating images unnnecessarily before april tag detection