### PR TITLE
pickle options and samplers and trajectories in spot env

### DIFF
--- a/predicators/envs/spot_env.py
+++ b/predicators/envs/spot_env.py
@@ -845,26 +845,28 @@ class SpotBikeEnv(SpotEnv):
             self._notHandEmpty, self._InViewTool, self._OnFloor
         }
 
-    def _handempty_classifier(self, state: State,
-                              objects: Sequence[Object]) -> bool:
+    @staticmethod
+    def _handempty_classifier(state: State, objects: Sequence[Object]) -> bool:
         spot = objects[0]
         gripper_open_percentage = state.get(spot, "gripper_open_percentage")
         return gripper_open_percentage <= 2.5
 
-    def _nothandempty_classifier(self, state: State,
+    @classmethod
+    def _nothandempty_classifier(cls, state: State,
                                  objects: Sequence[Object]) -> bool:
-        return not self._handempty_classifier(state, objects)
+        return not cls._handempty_classifier(state, objects)
 
-    def _holding_tool_classifier(self, state: State,
+    @classmethod
+    def _holding_tool_classifier(cls, state: State,
                                  objects: Sequence[Object]) -> bool:
         spot, obj_to_grasp = objects
         assert obj_name_to_apriltag_id.get(obj_to_grasp.name) is not None
         spot_holding_obj_id = state.get(spot, "curr_held_item_id")
         return int(spot_holding_obj_id) == obj_name_to_apriltag_id[
-            obj_to_grasp.name] and self._nothandempty_classifier(
-                state, [spot])
+            obj_to_grasp.name] and cls._nothandempty_classifier(state, [spot])
 
-    def _ontop_classifier(self, state: State,
+    @classmethod
+    def _ontop_classifier(cls, state: State,
                           objects: Sequence[Object]) -> bool:
         obj_on, obj_surface = objects
         assert obj_name_to_apriltag_id.get(obj_on.name) is not None
@@ -881,18 +883,19 @@ class SpotBikeEnv(SpotEnv):
             state.get(obj_surface, "z")
         ]
         is_x_same = np.sqrt(
-            (obj_on_pose[0] - obj_surface_pose[0])**2) <= self._ontop_threshold
+            (obj_on_pose[0] - obj_surface_pose[0])**2) <= cls._ontop_threshold
         is_y_same = np.sqrt(
-            (obj_on_pose[1] - obj_surface_pose[1])**2) <= self._ontop_threshold
+            (obj_on_pose[1] - obj_surface_pose[1])**2) <= cls._ontop_threshold
         is_above_z = (obj_on_pose[2] - obj_surface_pose[2]) > 0.0
         return is_x_same and is_y_same and is_above_z
 
-    def _onfloor_classifier(self, state: State,
-                            objects: Sequence[Object]) -> bool:
+    @staticmethod
+    def _onfloor_classifier(state: State, objects: Sequence[Object]) -> bool:
         obj_on, _ = objects
         return state.get(obj_on, "z") < 0.0
 
-    def _reachable_classifier(self, state: State,
+    @classmethod
+    def _reachable_classifier(cls, state: State,
                               objects: Sequence[Object]) -> bool:
         spot, obj = objects
         spot_pose = [
@@ -907,20 +910,23 @@ class SpotBikeEnv(SpotEnv):
         ]
         is_xy_near = np.sqrt(
             (spot_pose[0] - obj_pose[0])**2 +
-            (spot_pose[1] - obj_pose[1])**2) <= self._reachable_threshold
+            (spot_pose[1] - obj_pose[1])**2) <= cls._reachable_threshold
         is_z_near = np.sqrt((spot_pose[2] - obj_pose[2])**2) <= 0.85
         return is_xy_near and is_z_near
 
-    def _surface_too_high_classifier(self, state: State,
+    @staticmethod
+    def _surface_too_high_classifier(state: State,
                                      objects: Sequence[Object]) -> bool:
         _, surface = objects
         return state.get(surface, "z") > 1.0
 
-    def _surface_not_too_high_classifier(self, state: State,
+    @classmethod
+    def _surface_not_too_high_classifier(cls, state: State,
                                          objects: Sequence[Object]) -> bool:
-        return not self._surface_too_high_classifier(state, objects)
+        return not cls._surface_too_high_classifier(state, objects)
 
-    def _tool_in_view_classifier(self, state: State,
+    @staticmethod
+    def _tool_in_view_classifier(state: State,
                                  objects: Sequence[Object]) -> bool:
         _, tool = objects
         return state.get(tool, "in_view") > 0.5

--- a/predicators/ground_truth_models/spot/nsrts.py
+++ b/predicators/ground_truth_models/spot/nsrts.py
@@ -1,6 +1,7 @@
 """Ground-truth NSRTs for the PDDLEnv."""
 
-from typing import Dict, Sequence, Set
+from functools import partial
+from typing import Dict, Sequence, Set, Tuple
 
 import numpy as np
 from bosdyn.client import math_helpers
@@ -8,10 +9,130 @@ from bosdyn.client import math_helpers
 from predicators.envs import get_or_create_env
 from predicators.envs.spot_env import SpotEnv
 from predicators.ground_truth_models import GroundTruthNSRTFactory
-from predicators.spot_utils.spot_utils import get_spot_interface
-from predicators.structs import NSRT, Array, GroundAtom, Object, \
+from predicators.spot_utils.spot_utils import _SpotInterface, \
+    get_spot_interface
+from predicators.structs import NSRT, Array, GroundAtom, NSRTSampler, Object, \
     ParameterizedOption, Predicate, State, Type
 from predicators.utils import null_sampler
+
+
+# The functions below are NSRTSamplers with a spot_interface given as the
+# first argument. The code is structured this way to facilitate pickling.
+def _move_sampler(spot_interface: _SpotInterface, state: State,
+                  goal: Set[GroundAtom], rng: np.random.Generator,
+                  objs: Sequence[Object]) -> Array:
+    del goal
+    assert len(objs) in [2, 3]
+    if objs[1].type.name == "bag":  # pragma: no cover
+        return np.array([0.5, 0.0, 0.0])
+    # Sample dyaw so that there is some hope of seeing objects from
+    # different angles.
+    dyaw = rng.uniform(-np.pi / 8, np.pi / 8)
+    # For MoveToObjOnFloor
+    if len(objs) == 3:
+        if objs[2].name == "floor":
+            obj = objs[1]
+            # Get graph_nav to body frame.
+            gn_state = spot_interface.get_localized_state()
+            gn_origin_tform_body = math_helpers.SE3Pose.from_obj(
+                gn_state.localization.seed_tform_body)
+
+            # Transform fiducial pose for relative pose.
+            body_tform_fiducial = gn_origin_tform_body.inverse(
+            ).transform_point(state.get(obj, "x"), state.get(obj, "y"),
+                              state.get(obj, "z"))
+            obj_x, obj_y = [body_tform_fiducial[0], body_tform_fiducial[1]]
+
+            spot_xy = np.array([0.0, 0.0])
+            obj_xy = np.array([obj_x, obj_y])
+            distance = np.linalg.norm(obj_xy - spot_xy)
+            obj_unit_vector = (obj_xy - spot_xy) / distance
+
+            distance_to_obj = 1.25
+            new_xy = spot_xy + obj_unit_vector * (distance - distance_to_obj)
+            # Find the angle change needed to look at object
+            angle = np.arccos(
+                np.clip(np.dot(np.array([1.0, 0.0]), obj_unit_vector), -1.0,
+                        1.0))
+            # Check which direction with allclose
+            if not np.allclose(obj_unit_vector,
+                               [np.cos(angle), np.sin(angle)],
+                               atol=0.1):
+                angle = -angle
+            return np.array([new_xy[0], new_xy[1], angle + dyaw])
+    return np.array([-0.25, 0.0, dyaw])
+
+
+def _grasp_sampler(spot_interface: _SpotInterface, state: State,
+                   goal: Set[GroundAtom], rng: np.random.Generator,
+                   objs: Sequence[Object]) -> Array:
+    del state, goal, rng, spot_interface
+    if objs[1].type.name == "bag":  # pragma: no cover
+        return np.array([0.0, 0.0, 0.0, -1.0])
+    if objs[2].name == "low_wall_rack":  # pragma: no cover
+        return np.array([0.0, 0.0, 0.1, 0.0])
+    return np.array([0.0, 0.0, 0.0, 0.0])
+
+
+def _place_sampler(spot_interface: _SpotInterface, state: State,
+                   goal: Set[GroundAtom], rng: np.random.Generator,
+                   objs: Sequence[Object]) -> Array:
+    del goal
+    # Get graph_nav to body frame.
+    gn_state = spot_interface.get_localized_state()
+    gn_origin_tform_body = math_helpers.SE3Pose.from_obj(
+        gn_state.localization.seed_tform_body)
+
+    obj = objs[2]
+    # Apply transform to fiducial pose to get relative body location.
+    body_tform_fiducial = gn_origin_tform_body.inverse().transform_point(
+        state.get(obj, "x"), state.get(obj, "y"), state.get(obj, "z"))
+    fiducial_pose = np.array([
+        body_tform_fiducial[0], body_tform_fiducial[1], spot_interface.hand_z
+    ])
+    if objs[2].type.name == "bag":  # pragma: no cover
+        return fiducial_pose + np.array([0.1, 0.0, -0.25])
+    if "_table" in objs[2].name:
+        dx = rng.uniform(0.19, 0.21)
+        dy = rng.uniform(0.08, 0.22)
+        dz = rng.uniform(-0.61, -0.59)
+
+        # Oracle values for slanted table.
+        # dx = 0.2
+        # dy = 0.15
+        # dz = -0.6
+
+        return fiducial_pose + np.array([dx, dy, dz])
+    return fiducial_pose + np.array([0.0, 0.0, 0.0])
+
+
+_NAME_TO_SPOT_INTERFACE_SAMPLER = {
+    "move": _move_sampler,
+    "grasp": _grasp_sampler,
+    "place": _place_sampler,
+}
+
+
+class _SpotInterfaceSampler:
+    """A sampler that uses a spot interface.
+
+    Defined in this way to avoid pickling anything bosdyn related. The
+    key thing to note is that the args to __init__ are just strings, and
+    the magic happens in __getnewargs__().
+    """
+
+    def __init__(self, name: str) -> None:
+        self._name = name
+        spot_interface_sampler = _NAME_TO_SPOT_INTERFACE_SAMPLER[name]
+        spot_interface = get_spot_interface()
+        self._sampler = partial(spot_interface_sampler, spot_interface)
+
+    def __call__(self, state: State, goal: Set[GroundAtom],
+                 rng: np.random.Generator, objs: Sequence[Object]) -> Array:
+        return self._sampler(state, goal, rng, objs)
+
+    def __getnewargs__(self) -> Tuple:
+        return (self._name, )
 
 
 class SpotEnvsGroundTruthNSRTFactory(GroundTruthNSRTFactory):
@@ -19,105 +140,12 @@ class SpotEnvsGroundTruthNSRTFactory(GroundTruthNSRTFactory):
 
     @classmethod
     def get_env_names(cls) -> Set[str]:
-        return {"spot_grocery_env", "spot_bike_env"}
+        return {"spot_bike_env"}
 
     @staticmethod
     def get_nsrts(env_name: str, types: Dict[str, Type],
                   predicates: Dict[str, Predicate],
                   options: Dict[str, ParameterizedOption]) -> Set[NSRT]:
-
-        _spot_interface = get_spot_interface()
-
-        def move_sampler(state: State, goal: Set[GroundAtom],
-                         rng: np.random.Generator,
-                         objs: Sequence[Object]) -> Array:
-            del goal
-            assert len(objs) in [2, 3]
-            if objs[1].type.name == "bag":  # pragma: no cover
-                return np.array([0.5, 0.0, 0.0])
-            # Sample dyaw so that there is some hope of seeing objects from
-            # different angles.
-            dyaw = rng.uniform(-np.pi / 8, np.pi / 8)
-            # For MoveToObjOnFloor
-            if len(objs) == 3:
-                if objs[2].name == "floor":
-                    obj = objs[1]
-                    # Get graph_nav to body frame.
-                    gn_state = _spot_interface.get_localized_state()
-                    gn_origin_tform_body = math_helpers.SE3Pose.from_obj(
-                        gn_state.localization.seed_tform_body)
-
-                    # Transform fiducial pose for relative pose.
-                    body_tform_fiducial = gn_origin_tform_body.inverse(
-                    ).transform_point(state.get(obj, "x"), state.get(obj, "y"),
-                                      state.get(obj, "z"))
-                    obj_x, obj_y = [
-                        body_tform_fiducial[0], body_tform_fiducial[1]
-                    ]
-
-                    spot_xy = np.array([0.0, 0.0])
-                    obj_xy = np.array([obj_x, obj_y])
-                    distance = np.linalg.norm(obj_xy - spot_xy)
-                    obj_unit_vector = (obj_xy - spot_xy) / distance
-
-                    distance_to_obj = 1.25
-                    new_xy = spot_xy + obj_unit_vector * (distance -
-                                                          distance_to_obj)
-                    # Find the angle change needed to look at object
-                    angle = np.arccos(
-                        np.clip(np.dot(np.array([1.0, 0.0]), obj_unit_vector),
-                                -1.0, 1.0))
-                    # Check which direction with allclose
-                    if not np.allclose(
-                            obj_unit_vector,
-                        [np.cos(angle), np.sin(angle)],
-                            atol=0.1):
-                        angle = -angle
-                    return np.array([new_xy[0], new_xy[1], angle + dyaw])
-            return np.array([-0.25, 0.0, dyaw])
-
-        def grasp_sampler(state: State, goal: Set[GroundAtom],
-                          rng: np.random.Generator,
-                          objs: Sequence[Object]) -> Array:
-            del state, goal, rng
-            if objs[1].type.name == "bag":  # pragma: no cover
-                return np.array([0.0, 0.0, 0.0, -1.0])
-            if objs[2].name == "low_wall_rack":  # pragma: no cover
-                return np.array([0.0, 0.0, 0.1, 0.0])
-            return np.array([0.0, 0.0, 0.0, 0.0])
-
-        def place_sampler(state: State, goal: Set[GroundAtom],
-                          rng: np.random.Generator,
-                          objs: Sequence[Object]) -> Array:
-            del goal
-            # Get graph_nav to body frame.
-            gn_state = _spot_interface.get_localized_state()
-            gn_origin_tform_body = math_helpers.SE3Pose.from_obj(
-                gn_state.localization.seed_tform_body)
-
-            obj = objs[2]
-            # Apply transform to fiducial pose to get relative body location.
-            body_tform_fiducial = gn_origin_tform_body.inverse(
-            ).transform_point(state.get(obj, "x"), state.get(obj, "y"),
-                              state.get(obj, "z"))
-            fiducial_pose = np.array([
-                body_tform_fiducial[0], body_tform_fiducial[1],
-                _spot_interface.hand_z
-            ])
-            if objs[2].type.name == "bag":  # pragma: no cover
-                return fiducial_pose + np.array([0.1, 0.0, -0.25])
-            if "_table" in objs[2].name:
-                dx = rng.uniform(0.19, 0.21)
-                dy = rng.uniform(0.08, 0.22)
-                dz = rng.uniform(-0.61, -0.59)
-
-                # Oracle values for slanted table.
-                # dx = 0.2
-                # dy = 0.15
-                # dz = -0.6
-
-                return fiducial_pose + np.array([dx, dy, dz])
-            return fiducial_pose + np.array([0.0, 0.0, 0.0])
 
         env = get_or_create_env(env_name)
         assert isinstance(env, SpotEnv)
@@ -125,31 +153,20 @@ class SpotEnvsGroundTruthNSRTFactory(GroundTruthNSRTFactory):
         nsrts = set()
 
         for strips_op in env.strips_operators:
-            option = options[strips_op.name]
             if "MoveTo" in strips_op.name:
-                nsrt = strips_op.make_nsrt(
-                    option=option,
-                    option_vars=strips_op.parameters,
-                    sampler=move_sampler,
-                )
+                sampler: NSRTSampler = _SpotInterfaceSampler("move")
             elif "Grasp" in strips_op.name:
-                nsrt = strips_op.make_nsrt(
-                    option=option,
-                    option_vars=strips_op.parameters,
-                    sampler=grasp_sampler,
-                )
+                sampler = _SpotInterfaceSampler("grasp")
             elif "Place" in strips_op.name:
-                nsrt = strips_op.make_nsrt(
-                    option=option,
-                    option_vars=strips_op.parameters,
-                    sampler=place_sampler,
-                )
+                sampler = _SpotInterfaceSampler("place")
             else:
-                nsrt = strips_op.make_nsrt(
-                    option=option,
-                    option_vars=strips_op.parameters,
-                    sampler=null_sampler,
-                )
+                sampler = null_sampler
+            option = options[strips_op.name]
+            nsrt = strips_op.make_nsrt(
+                option=option,
+                option_vars=strips_op.parameters,
+                sampler=sampler,
+            )
             nsrts.add(nsrt)
 
         return nsrts

--- a/predicators/ground_truth_models/spot/options.py
+++ b/predicators/ground_truth_models/spot/options.py
@@ -1,6 +1,6 @@
 """Ground-truth options for PDDL environments."""
 
-from typing import Dict, Sequence, Set
+from typing import Dict, List, Sequence, Set, Tuple
 
 from gym.spaces import Box
 
@@ -12,12 +12,63 @@ from predicators.structs import Action, Array, Object, ParameterizedOption, \
     Predicate, State, STRIPSOperator, Type
 
 
+class _SpotEnvOption(utils.SingletonParameterizedOption):
+    """An option defined by an operator in the spot environment.
+
+    Defined in this way to avoid pickling anything bosdyn related. The
+    key thing to note is that the args to __init__ are just strings, and
+    the magic happens in __getnewargs__().
+    """
+
+    def __init__(self, operator_name: str, env_name: str) -> None:
+        self._operator_name = operator_name
+        self._env_name = env_name
+        types = [p.type for p in self._get_operator().parameters]
+        policy = self._policy_from_operator
+        params_space = self._create_params_space()
+        super().__init__(self._operator_name,
+                         policy,
+                         types,
+                         params_space=params_space)
+
+    def __getnewargs__(self) -> Tuple:
+        return (self._operator_name, self._env_name)
+
+    def _get_env(self) -> SpotEnv:
+        env = get_or_create_env(self._env_name)
+        assert isinstance(env, SpotEnv)
+        return env
+
+    def _get_operator(self) -> STRIPSOperator:
+        matches = [
+            op for op in self._get_env().strips_operators
+            if op.name == self._operator_name
+        ]
+        assert len(matches) == 1
+        return matches[0]
+
+    def _policy_from_operator(self, s: State, m: Dict, o: Sequence[Object],
+                              p: Array) -> Action:
+        del s, m  # unused
+        operator = self._get_operator()
+        return self._get_env().build_action(operator, o, p)
+
+    def _types_from_operator(self) -> List[Type]:
+        return [p.type for p in self._get_operator().parameters]
+
+    def _create_params_space(self) -> Box:
+        env = self._get_env()
+        operator = self._get_operator()
+        controller_name = env.operator_to_controller_name(operator)
+        return env.controller_name_to_param_space(controller_name)
+
+
 class SpotEnvsGroundTruthOptionFactory(GroundTruthOptionFactory):
     """Ground-truth options for PDDL environments."""
 
     @classmethod
     def get_env_names(cls) -> Set[str]:
-        return {"spot_grocery_env", "spot_bike_env"}
+        return {"spot_bike_env"}
 
     @classmethod
     def get_options(cls, env_name: str, types: Dict[str, Type],
@@ -26,25 +77,8 @@ class SpotEnvsGroundTruthOptionFactory(GroundTruthOptionFactory):
         # Note that these are 1:1 with the operators.
         env = get_or_create_env(env_name)
         assert isinstance(env, SpotEnv)
-        options = {
-            cls._strips_operator_to_parameterized_option(op, env)
+        options: Set[ParameterizedOption] = {
+            _SpotEnvOption(op.name, env_name)
             for op in env.strips_operators
         }
         return options
-
-    @staticmethod
-    def _strips_operator_to_parameterized_option(
-            op: STRIPSOperator, env: SpotEnv) -> ParameterizedOption:
-
-        def policy(s: State, m: Dict, o: Sequence[Object], p: Array) -> Action:
-            del s, m  # unused
-            return env.build_action(op, o, p)
-
-        controller_name = env.operator_to_controller_name(op)
-        params_space = env.controller_name_to_param_space(controller_name)
-        types = [p.type for p in op.parameters]
-
-        return utils.SingletonParameterizedOption(op.name,
-                                                  policy,
-                                                  types,
-                                                  params_space=params_space)

--- a/predicators/main.py
+++ b/predicators/main.py
@@ -341,11 +341,8 @@ def _run_testing(env: BaseEnv, cogman: CogMan) -> Metrics:
                 "trajectory": traj,
                 "pybullet_robot": CFG.pybullet_robot
             }
-            # Our spot controllers are not pickleable for annoying reasons,
-            # so don't try to pickle any of these environments.
-            if CFG.env not in ["spot_bike_env", "spot_grocery_env"]:
-                with open(traj_file_path, "wb") as f:
-                    pkl.dump(traj_data, f)
+            with open(traj_file_path, "wb") as f:
+                pkl.dump(traj_data, f)
         except utils.EnvironmentFailure as e:
             log_message = f"Environment failed with error: {e}"
             caught_exception = True

--- a/predicators/settings.py
+++ b/predicators/settings.py
@@ -176,6 +176,7 @@ class GlobalSettings:
     spot_grasp_use_cv2 = False
     spot_cube_only = False
     spot_initialize_surfaces_to_default = True
+    spot_fiducial_size = 44.45
 
     # pddl blocks env parameters
     pddl_blocks_procedural_train_min_num_blocks = 3

--- a/predicators/spot_utils/spot_utils.py
+++ b/predicators/spot_utils/spot_utils.py
@@ -356,9 +356,9 @@ class _SpotInterface():
         return state
 
     def get_apriltag_pose_from_camera(
-            self,
-            source_name: str = "hand_color_image",
-            fiducial_size: float = CFG.spot_fiducial_size,
+        self,
+        source_name: str = "hand_color_image",
+        fiducial_size: float = CFG.spot_fiducial_size,
     ) -> Dict[int, Tuple[float, float, float]]:
         """Get the poses of all fiducials in camera view.
 

--- a/predicators/spot_utils/spot_utils.py
+++ b/predicators/spot_utils/spot_utils.py
@@ -358,7 +358,7 @@ class _SpotInterface():
     def get_apriltag_pose_from_camera(
             self,
             source_name: str = "hand_color_image",
-            fiducial_size: float = 76.2
+            fiducial_size: float = CFG.spot_fiducial_size,
     ) -> Dict[int, Tuple[float, float, float]]:
         """Get the poses of all fiducials in camera view.
 


### PR DESCRIPTION
this now saves trajectories:

```python predicators/main.py --env spot_bike_env --approach spot_wrapper[oracle] --seed 0 --num_train_tasks 0 --num_test_tasks 1 --spot_robot_ip 10.17.30.30 --bilevel_plan_without_sim True --spot_grasp_use_apriltag True --perceiver spot_bike_env --spot_cube_only True```