### PR TITLE
Massive vision pipeline refactor to enable batching + improve speed

### DIFF
--- a/predicators/envs/spot_env.py
+++ b/predicators/envs/spot_env.py
@@ -313,20 +313,20 @@ class SpotEnv(BaseEnv):
         may vary per environment.
         """
         # Get the camera images.
-        rgb_img_dict, rgb_img_response_dict, _, depth_img_response_dict = self._spot_interface.get_camera_images(
+        rgb_img_dict, rgb_img_response_dict, depth_img_dict, depth_img_response_dict = self._spot_interface.get_camera_images(
         )
 
         # Detect objects using AprilTags (which we need for surfaces anyways).
         object_names_in_view_by_camera = {}
         object_names_in_view_by_camera_apriltag = \
             self._spot_interface.get_objects_in_view_by_camera\
-                (from_apriltag=True, rgb_image_dict=rgb_img_dict, rgb_image_response_dict=rgb_img_response_dict, depth_image_response_dict=depth_img_response_dict)
+                (from_apriltag=True, rgb_image_dict=rgb_img_dict, rgb_image_response_dict=rgb_img_response_dict, depth_image_dict=depth_img_dict, depth_image_response_dict=depth_img_response_dict)
         object_names_in_view_by_camera.update(
             object_names_in_view_by_camera_apriltag)
         # Additionally, if we're using SAM, then update using that.
         if CFG.spot_grasp_use_sam:
             object_names_in_view_by_camera_sam = self._spot_interface.\
-                get_objects_in_view_by_camera(from_apriltag=False, rgb_image_dict=rgb_img_dict, rgb_image_response_dict=rgb_img_response_dict, depth_image_response_dict=depth_img_response_dict)
+                get_objects_in_view_by_camera(from_apriltag=False, rgb_image_dict=rgb_img_dict, rgb_image_response_dict=rgb_img_response_dict, depth_image_dict=depth_img_dict, depth_image_response_dict=depth_img_response_dict)
             # Combine these together to get all objects in view.
             for k, v in object_names_in_view_by_camera.items():
                 v.update(object_names_in_view_by_camera_sam[k])

--- a/predicators/envs/spot_env.py
+++ b/predicators/envs/spot_env.py
@@ -313,20 +313,30 @@ class SpotEnv(BaseEnv):
         may vary per environment.
         """
         # Get the camera images.
-        rgb_img_dict, rgb_img_response_dict, depth_img_dict, depth_img_response_dict = self._spot_interface.get_camera_images(
-        )
+        rgb_img_dict, rgb_img_response_dict, \
+            depth_img_dict, depth_img_response_dict = \
+                    self._spot_interface.get_camera_images()
 
         # Detect objects using AprilTags (which we need for surfaces anyways).
         object_names_in_view_by_camera = {}
         object_names_in_view_by_camera_apriltag = \
             self._spot_interface.get_objects_in_view_by_camera\
-                (from_apriltag=True, rgb_image_dict=rgb_img_dict, rgb_image_response_dict=rgb_img_response_dict, depth_image_dict=depth_img_dict, depth_image_response_dict=depth_img_response_dict)
+                (from_apriltag=True, rgb_image_dict=rgb_img_dict,
+                 rgb_image_response_dict=rgb_img_response_dict,
+                 depth_image_dict=depth_img_dict,
+                 depth_image_response_dict=depth_img_response_dict)
         object_names_in_view_by_camera.update(
             object_names_in_view_by_camera_apriltag)
         # Additionally, if we're using SAM, then update using that.
         if CFG.spot_grasp_use_sam:
             object_names_in_view_by_camera_sam = self._spot_interface.\
-                get_objects_in_view_by_camera(from_apriltag=False, rgb_image_dict=rgb_img_dict, rgb_image_response_dict=rgb_img_response_dict, depth_image_dict=depth_img_dict, depth_image_response_dict=depth_img_response_dict)
+                get_objects_in_view_by_camera(from_apriltag=False,
+                                            rgb_image_dict=rgb_img_dict,
+                                            rgb_image_response_dict=\
+                                                rgb_img_response_dict,
+                                            depth_image_dict=depth_img_dict,
+                                            depth_image_response_dict=\
+                                                depth_img_response_dict)
             # Combine these together to get all objects in view.
             for k, v in object_names_in_view_by_camera.items():
                 v.update(object_names_in_view_by_camera_sam[k])
@@ -426,13 +436,13 @@ class SpotEnv(BaseEnv):
         }
         robot_type = next(t for t in self.types if t.name == "robot")
         robot = Object("spot", robot_type)
-        images = self._spot_interface.get_camera_images()
+        rgb_images, _, _, _ = self._spot_interface.get_camera_images()
         gripper_open_percentage = self._spot_interface.get_gripper_obs()
         robot_pos = self._spot_interface.get_robot_pose()
         nonpercept_atoms = self._get_initial_nonpercept_atoms()
         nonpercept_preds = self.predicates - self.percept_predicates
         assert all(a.predicate in nonpercept_preds for a in nonpercept_atoms)
-        obs = _SpotObservation(images, objects_in_view, set(), robot,
+        obs = _SpotObservation(rgb_images, objects_in_view, set(), robot,
                                gripper_open_percentage, robot_pos,
                                nonpercept_atoms, nonpercept_preds)
         goal = self._generate_task_goal()

--- a/predicators/spot_utils/perception_utils.py
+++ b/predicators/spot_utils/perception_utils.py
@@ -12,13 +12,14 @@ import dill as pkl
 import matplotlib
 import matplotlib.pyplot as plt
 import numpy as np
+import PIL
 import requests
 from bosdyn.api import image_pb2
 from numpy.typing import NDArray
-from PIL import Image
 from scipy import ndimage
 
 from predicators.settings import CFG
+from predicators.structs import Image
 
 # NOTE: uncomment this line if trying to visualize stuff locally
 # and matplotlib isn't displaying.
@@ -32,9 +33,21 @@ ROTATION_ANGLE = {
     'left_fisheye_image': 0,
     'right_fisheye_image': 180
 }
+CAMERA_NAMES = [
+    "hand_color_image", "left_fisheye_image", "right_fisheye_image",
+    "frontleft_fisheye_image", "frontright_fisheye_image", "back_fisheye_image"
+]
+RGB_TO_DEPTH_CAMERAS = {
+    "hand_color_image": "hand_depth_in_hand_color_frame",
+    "left_fisheye_image": "left_depth_in_visual_frame",
+    "right_fisheye_image": "right_depth_in_visual_frame",
+    "frontleft_fisheye_image": "frontleft_depth_in_visual_frame",
+    "frontright_fisheye_image": "frontright_depth_in_visual_frame",
+    "back_fisheye_image": "back_depth_in_visual_frame"
+}
 
 
-def image_to_bytes(img: Image.Image) -> io.BytesIO:
+def image_to_bytes(img: PIL.Image.Image) -> io.BytesIO:
     """Helper function to convert from a PIL image into a bytes object."""
     buf = io.BytesIO()
     img.save(buf, format="PNG")
@@ -42,7 +55,7 @@ def image_to_bytes(img: Image.Image) -> io.BytesIO:
     return buf
 
 
-def visualize_output(im: Image.Image, masks: NDArray, input_boxes: NDArray,
+def visualize_output(im: PIL.Image.Image, masks: NDArray, input_boxes: NDArray,
                      classes: NDArray, scores: NDArray) -> None:
     """Visualizes the output of SAM; useful for debugging.
 
@@ -98,73 +111,87 @@ def show_box(box: NDArray, ax: matplotlib.axes.Axes) -> None:
                       lw=2))
 
 
-def query_detic_sam(image_in: NDArray, classes: List[str],
-                    viz: bool) -> Dict[str, List[NDArray]]:
+def query_detic_sam(rgb_image_dict_in: Dict[str, Image], classes: List[str],
+                    viz: bool) -> Dict[str, Dict[str, List[NDArray]]]:
     """Send a query to SAM and return the response.
 
-    The response is a dictionary that contains 4 keys: 'boxes',
-    'classes', 'masks' and 'scores'.
+    TODO
     """
-    image = Image.fromarray(image_in)
-    buf = image_to_bytes(image)
-    r = requests.post("http://localhost:5550/predict",
-                      files={"file": buf},
+    buf_dict = {}
+    for source_name in rgb_image_dict_in.keys():
+        image = PIL.Image.fromarray(rgb_image_dict_in[source_name])
+        buf_dict[source_name] = image_to_bytes(image)
+
+    r = requests.post("http://localhost:5550/batch_predict",
+                      files=buf_dict,
                       data={"classes": ",".join(classes)})
 
-    d_filtered: Dict[str, List[NDArray]] = {
-        "boxes": [],
-        "classes": [],
-        "masks": [],
-        "scores": []
-    }
+    detic_sam_results: Dict[str, Dict[str, List[NDArray]]] = {}
+    for source_name in rgb_image_dict_in.keys():
+        detic_sam_results[source_name] = {
+            "boxes": [],
+            "classes": [],
+            "masks": [],
+            "scores": []
+        }
+
     # If the status code is not 200, then fail.
     if r.status_code != 200:
-        return d_filtered
+        return detic_sam_results
 
     with io.BytesIO(r.content) as f:
         try:
             arr = np.load(f, allow_pickle=True)
         except pkl.UnpicklingError:
-            return d_filtered
+            return detic_sam_results
+        for source_name in rgb_image_dict_in.keys():
+            curr_boxes = arr[source_name + '_boxes']
+            curr_ret_classes = arr[source_name + '_classes']
+            curr_masks = arr[source_name + '_masks']
+            curr_scores = arr[source_name + '_scores']
 
-        boxes = arr['boxes']
-        ret_classes = arr['classes']
-        masks = arr['masks']
-        scores = arr['scores']
+            # If there were no detections (which means all the
+            # returned values will be numpy arrays of shape (0, 0))
+            # then just skip this source.
+            if curr_ret_classes.size == 0:
+                continue
 
-    d = {
-        "boxes": boxes,
-        "classes": ret_classes,
-        "masks": masks,
-        "scores": scores
-    }
+            d = {
+                "boxes": curr_boxes,
+                "classes": curr_ret_classes,
+                "masks": curr_masks,
+                "scores": curr_scores
+            }
 
-    if viz:
-        # Optional visualization useful for debugging.
-        visualize_output(image, d["masks"], d["boxes"], d["classes"],
-                         d["scores"])
+            if viz:
+                image = PIL.Image.fromarray(rgb_image_dict_in[source_name])
+                # Optional visualization useful for debugging.
+                visualize_output(image, d["masks"], d["boxes"], d["classes"],
+                                 d["scores"])
 
-    # Filter out detections by confidence. We threshold detections
-    # at a set confidence level minimum, and if there are multiple
-    #, we only select the most confident one. This structure makes
-    # it easy for us to select multiple detections if that's ever
-    # necessary in the future.
-    for obj_class in classes:
-        class_mask = (d['classes'] == obj_class)
-        if not np.any(class_mask):
-            continue
-        max_score = np.max(d['scores'][class_mask])
-        max_score_idx = np.where(d['scores'] == max_score)[0]
-        if d['scores'][max_score_idx] < CFG.spot_vision_detection_threshold:
-            continue
-        for key, value in d.items():
-            # Sanity check to ensure that we're selecting a value from
-            # the class we're looking for.
-            if key == "classes":
-                assert value[max_score_idx] == obj_class
-            d_filtered[key].append(value[max_score_idx])
+            # Filter out detections by confidence. We threshold detections
+            # at a set confidence level minimum, and if there are multiple
+            #, we only select the most confident one. This structure makes
+            # it easy for us to select multiple detections if that's ever
+            # necessary in the future.
+            for obj_class in classes:
+                class_mask = (d['classes'] == obj_class)
+                if not np.any(class_mask):
+                    continue
+                max_score = np.max(d['scores'][class_mask])
+                max_score_idx = np.where(d['scores'] == max_score)[0]
+                if d['scores'][
+                        max_score_idx] < CFG.spot_vision_detection_threshold:
+                    continue
+                for key, value in d.items():
+                    # Sanity check to ensure that we're selecting a value from
+                    # the class we're looking for.
+                    if key == "classes":
+                        assert value[max_score_idx] == obj_class
+                    detic_sam_results[source_name][key].append(
+                        value[max_score_idx])
 
-    return d_filtered
+    return detic_sam_results
 
 
 # NOTE: the below function is useful for visualization; uncomment
@@ -249,50 +276,6 @@ def query_detic_sam(image_in: NDArray, classes: List[str],
 #     return np.vstack((x, y, z)).T, valid_inds
 
 
-def process_image_response(image_response: bosdyn.api.image_pb2.ImageResponse,
-                           to_rgb: bool = False) -> NDArray:
-    """Given a Boston Dynamics SDK image response, extract the correct np array
-    corresponding to the image."""
-    # pylint: disable=no-member
-    num_bytes = 1  # Assume a default of 1 byte encodings.
-    if image_response.shot.image.pixel_format == \
-            image_pb2.Image.PIXEL_FORMAT_DEPTH_U16:
-        dtype = np.uint16
-    else:
-        if image_response.shot.image.pixel_format == \
-                image_pb2.Image.PIXEL_FORMAT_RGB_U8:
-            num_bytes = 3
-        elif image_response.shot.image.pixel_format == \
-                image_pb2.Image.PIXEL_FORMAT_RGBA_U8:
-            num_bytes = 4
-        elif image_response.shot.image.pixel_format == \
-                image_pb2.Image.PIXEL_FORMAT_GREYSCALE_U8:
-            num_bytes = 1
-        elif image_response.shot.image.pixel_format == \
-                image_pb2.Image.PIXEL_FORMAT_GREYSCALE_U16:
-            num_bytes = 2
-        dtype = np.uint8  # type: ignore
-
-    img = np.frombuffer(image_response.shot.image.data, dtype=dtype)
-    if image_response.shot.image.format == image_pb2.Image.FORMAT_RAW:
-        try:
-            # Attempt to reshape array into a RGB rows X cols shape.
-            img = img.reshape((image_response.shot.image.rows,
-                               image_response.shot.image.cols, num_bytes))
-        except ValueError:
-            # Unable to reshape the image data, trying a regular decode.
-            img = cv2.imdecode(img, -1)
-    else:
-        img = cv2.imdecode(img, -1)
-
-    # Convert to RGB color, as some perception models assume RGB format
-    # By default, still use BGR to keep backward compability
-    if to_rgb:
-        img = cv2.cvtColor(img, cv2.COLOR_BGR2RGB)
-
-    return img
-
-
 def get_xyz_from_depth(image_response: bosdyn.api.image_pb2.ImageResponse,
                        depth_value: float, point_x: float,
                        point_y: float) -> Tuple[float, float, float]:
@@ -327,26 +310,29 @@ def get_xyz_from_depth(image_response: bosdyn.api.image_pb2.ImageResponse,
 
 def get_pixel_locations_with_detic_sam(
         obj_class: str,
-        in_res_image: Dict[str, NDArray],
+        rgb_image_dict: Dict[str, NDArray],
         plot: bool = False) -> List[Tuple[float, float]]:
     """Method to get the pixel locations of specific objects with class names
     listed in 'classes' within an input image."""
-    res_segment = query_detic_sam(image_in=in_res_image['rgb'],
+    res_segment = query_detic_sam(rgb_image_dict_in=rgb_image_dict,
                                   classes=[obj_class],
                                   viz=plot)
-    # return: 'masks', 'boxes', 'classes'
-    if len(res_segment['classes']) == 0:
-        return []
+
+    assert len(rgb_image_dict.keys()) == 1
+    camera_name = list(rgb_image_dict.keys())[0]
+    if len(res_segment[camera_name]['classes']) == 0:
+        return pixel_locations
+
 
     pixel_locations = []
 
     # Compute geometric center of object bounding box
-    x1, y1, x2, y2 = res_segment['boxes'][0].squeeze()
+    x1, y1, x2, y2 = res_segment[camera_name]['boxes'][0].squeeze()
     x_c = (x1 + x2) / 2
     y_c = (y1 + y2) / 2
     # Plot center and segmentation mask
     if plot:
-        plt.imshow(res_segment['masks'][0][0].squeeze())
+        plt.imshow(res_segment[camera_name]['masks'][0][0].squeeze())
         plt.show()
     pixel_locations.append((x_c, y_c))
 
@@ -355,9 +341,10 @@ def get_pixel_locations_with_detic_sam(
 
 def get_object_locations_with_detic_sam(
         classes: List[str],
-        res_image: Dict[str, NDArray],
-        res_image_responses: Dict[str, bosdyn.api.image_pb2.ImageResponse],
-        source_name: str,
+        rgb_image_dict: Dict[str, Image],
+        depth_image_dict: Dict[str, Image],
+        depth_image_response_dict: Dict[str,
+                                        bosdyn.api.image_pb2.ImageResponse],
         plot: bool = False) -> Dict[str, Tuple[float, float, float]]:
     """Given a list of string queries (classes), call SAM on these and return
     the positions of the centroids of these detections in the camera frame.
@@ -371,97 +358,111 @@ def get_object_locations_with_detic_sam(
     # First, rotate the rgb and depth images by the correct angle.
     # Importantly, DO NOT reshape the image, because this will
     # lead to a bunch of problems when we reverse the rotation later.
-    rotated_rgb = ndimage.rotate(res_image['rgb'],
-                                 ROTATION_ANGLE[source_name],
-                                 reshape=False)
-    rotated_depth = ndimage.rotate(res_image['depth'],
-                                   ROTATION_ANGLE[source_name],
-                                   reshape=False)
+    rotated_rgb_image_dict = {}
+    rotated_depth_image_dict = {}
+    for source_name in CAMERA_NAMES:
+        assert source_name in rgb_image_dict and source_name in depth_image_dict
+        rotated_rgb = ndimage.rotate(rgb_image_dict[source_name],
+                                     ROTATION_ANGLE[source_name],
+                                     reshape=False)
+        rotated_depth = ndimage.rotate(depth_image_dict[source_name],
+                                       ROTATION_ANGLE[source_name],
+                                       reshape=False)
+        rotated_rgb_image_dict[source_name] = rotated_rgb
+        rotated_depth_image_dict[source_name] = rotated_depth
 
-    # Plot the rotated image before querying SAM.
-    if plot:
-        plt.imshow(rotated_rgb)
-        plt.show()
-
-    # Start by querying SAM
-    res_segment = query_detic_sam(image_in=rotated_rgb,
-                                  classes=classes,
-                                  viz=plot)
-
-    if len(res_segment['classes']) == 0:
-        return {}
-
-    ret_obj_positions: Dict[str, Tuple[float, float, float]] = {}
-    for i, obj_class in enumerate(res_segment['classes']):
-        # Check that this particular class is one of the
-        # classes we passed in, and that there was only one
-        # instance of this class that was found.
-        assert obj_class.item() in classes
-        assert res_segment['classes'].count(obj_class) == 1
-        # Compute median value of depth
-        depth_median = np.median(
-            rotated_depth[res_segment['masks'][i][0].squeeze()
-                          & (rotated_depth > 2)[:, :, 0]])
-        # Compute geometric center of object bounding box
-        x1, y1, x2, y2 = res_segment['boxes'][i].squeeze()
-        x_c = (x1 + x2) / 2
-        y_c = (y1 + y2) / 2
-        # Create a transformation matrix for the rotation. Be very
-        # careful to use radians, since np.cos and np.sin expect
-        # angles in radians and not degrees.
-        rotation_radians = np.radians(ROTATION_ANGLE[source_name])
-        transform_matrix = np.array(
-            [[np.cos(rotation_radians), -np.sin(rotation_radians)],
-             [np.sin(rotation_radians),
-              np.cos(rotation_radians)]])
-        # Subtract the center of the image from the pixel location to
-        # translate the rotation to the origin.
-        center = np.array(
-            [rotated_rgb.shape[1] / 2., rotated_rgb.shape[0] / 2.])
-        pixel_centered = np.array([x_c, y_c]) - center
-        # Apply the rotation
-        rotated_pixel_centered = np.matmul(transform_matrix, pixel_centered)
-        # Add the center of the image back to the pixel location to
-        # translate the rotation back from the origin.
-        rotated_pixel = rotated_pixel_centered + center
-        # Now rotated_pixel is the location of the centroid pixel after the
-        # inverse rotation.
-        x_c_rotated = rotated_pixel[0]
-        y_c_rotated = rotated_pixel[1]
-
-        # Plot (1) the original RGB image, (2) the rotated
-        # segmentation mask from SAM on top of it, (3) the
-        # center of the image, (4) the centroid of the detected
-        # object that comes from SAM, and (5) the centroid
-        # after we rotate it back to align with the original
-        # RGB image.
+        # Plot the rotated image before querying DETIC-SAM.
         if plot:
-            inverse_rotation_angle = -ROTATION_ANGLE[source_name]
-            plt.imshow(res_image['depth'])
-            plt.imshow(ndimage.rotate(res_segment['masks'][i][0].squeeze(),
-                                      inverse_rotation_angle,
-                                      reshape=False),
-                       alpha=0.5,
-                       cmap='Reds')
-            plt.scatter(x=x_c_rotated,
-                        y=y_c_rotated,
-                        marker='*',
-                        color='red',
-                        zorder=3)
-            plt.scatter(x=center[0],
-                        y=center[1],
-                        marker='.',
-                        color='blue',
-                        zorder=3)
-            plt.scatter(x=x_c, y=y_c, marker='*', color='green', zorder=3)
+            plt.imshow(rotated_rgb)
             plt.show()
 
-        # Get XYZ of the point at center of bounding box and median depth value.
-        x0, y0, z0 = get_xyz_from_depth(res_image_responses['depth'],
-                                        depth_value=depth_median,
-                                        point_x=x_c_rotated,
-                                        point_y=y_c_rotated)
-        if not math.isnan(x0) and not math.isnan(y0) and not math.isnan(z0):
-            ret_obj_positions[obj_class.item()] = (x0, y0, z0)
+    # Start by querying the DETIC-SAM model.
+    deticsam_results_all_cameras = query_detic_sam(
+        rgb_image_dict_in=rotated_rgb_image_dict, classes=classes, viz=plot)
 
-    return ret_obj_positions
+    ret_camera_to_obj_positions: Dict[str,
+                                      Dict[str,
+                                           Tuple[float, float, float]]] = {
+                                               source_name: {}
+                                               for source_name in CAMERA_NAMES
+                                           }
+    for source_name in CAMERA_NAMES:
+        curr_res_segment = deticsam_results_all_cameras[source_name]
+        for i, obj_class in enumerate(curr_res_segment['classes']):
+            # Check that this particular class is one of the
+            # classes we passed in, and that there was only one
+            # instance of this class that was found.
+            assert obj_class.item() in classes
+            assert curr_res_segment['classes'].count(obj_class) == 1
+            # Compute median value of depth
+            depth_median = np.median(
+                rotated_depth[curr_res_segment['masks'][i][0].squeeze()
+                              & (rotated_depth > 2)[:, :, 0]])
+            # Compute geometric center of object bounding box
+            x1, y1, x2, y2 = curr_res_segment['boxes'][i].squeeze()
+            x_c = (x1 + x2) / 2
+            y_c = (y1 + y2) / 2
+            # Create a transformation matrix for the rotation. Be very
+            # careful to use radians, since np.cos and np.sin expect
+            # angles in radians and not degrees.
+            rotation_radians = np.radians(ROTATION_ANGLE[source_name])
+            transform_matrix = np.array(
+                [[np.cos(rotation_radians), -np.sin(rotation_radians)],
+                 [np.sin(rotation_radians),
+                  np.cos(rotation_radians)]])
+            # Subtract the center of the image from the pixel location to
+            # translate the rotation to the origin.
+            center = np.array(
+                [rotated_rgb.shape[1] / 2., rotated_rgb.shape[0] / 2.])
+            pixel_centered = np.array([x_c, y_c]) - center
+            # Apply the rotation
+            rotated_pixel_centered = np.matmul(transform_matrix,
+                                               pixel_centered)
+            # Add the center of the image back to the pixel location to
+            # translate the rotation back from the origin.
+            rotated_pixel = rotated_pixel_centered + center
+            # Now rotated_pixel is the location of the centroid pixel after the
+            # inverse rotation.
+            x_c_rotated = rotated_pixel[0]
+            y_c_rotated = rotated_pixel[1]
+
+            # Plot (1) the original RGB image, (2) the rotated
+            # segmentation mask from SAM on top of it, (3) the
+            # center of the image, (4) the centroid of the detected
+            # object that comes from SAM, and (5) the centroid
+            # after we rotate it back to align with the original
+            # RGB image.
+            if plot:
+                inverse_rotation_angle = -ROTATION_ANGLE[source_name]
+                plt.imshow(depth_image_dict[source_name])
+                plt.imshow(ndimage.rotate(
+                    curr_res_segment['masks'][i][0].squeeze(),
+                    inverse_rotation_angle,
+                    reshape=False),
+                           alpha=0.5,
+                           cmap='Reds')
+                plt.scatter(x=x_c_rotated,
+                            y=y_c_rotated,
+                            marker='*',
+                            color='red',
+                            zorder=3)
+                plt.scatter(x=center[0],
+                            y=center[1],
+                            marker='.',
+                            color='blue',
+                            zorder=3)
+                plt.scatter(x=x_c, y=y_c, marker='*', color='green', zorder=3)
+                plt.show()
+
+            # Get XYZ of the point at center of bounding box and median depth value.
+            x0, y0, z0 = get_xyz_from_depth(
+                depth_image_response_dict[source_name],
+                depth_value=depth_median,
+                point_x=x_c_rotated,
+                point_y=y_c_rotated)
+            if not math.isnan(x0) and not math.isnan(y0) and not math.isnan(
+                    z0):
+                ret_camera_to_obj_positions[source_name][obj_class.item()] = (
+                    x0, y0, z0)
+
+    return ret_camera_to_obj_positions

--- a/predicators/spot_utils/perception_utils.py
+++ b/predicators/spot_utils/perception_utils.py
@@ -22,7 +22,7 @@ from predicators.settings import CFG
 
 # NOTE: uncomment this line if trying to visualize stuff locally
 # and matplotlib isn't displaying.
-# matplotlib.use('TkAgg')
+matplotlib.use('TkAgg')
 
 ROTATION_ANGLE = {
     'hand_color_image': 0,
@@ -151,7 +151,7 @@ def query_detic_sam(image_in: NDArray, classes: List[str],
     # necessary in the future.
     for obj_class in classes:
         class_mask = (d['classes'] == obj_class)
-        if np.any(class_mask):
+        if not np.any(class_mask):
             continue
         max_score = np.max(d['scores'][class_mask])
         max_score_idx = np.where(d['scores'] == max_score)[0]

--- a/predicators/spot_utils/spot_utils.py
+++ b/predicators/spot_utils/spot_utils.py
@@ -380,9 +380,8 @@ class _SpotInterface():
         object_views: Dict[str, Tuple[float, float, float]] = {}
         if CFG.spot_initialize_surfaces_to_default:
             object_views = {
-                "tool_room_table":
-                (6.939992779470081, -6.21562847222872, 0.030711182602548265),
-                "extra_room_table": (8.24384, -6.27615, -0.0035917),
+                "tool_room_table": (6.63041, -6.35143, 0.179613),
+                "extra_room_table": (8.27387, -6.23233, -0.0678132),
                 "low_wall_rack":
                 (10.049931203338616, -6.9443170697742, 0.27881268568327966),
                 "toolbag":


### PR DESCRIPTION
This PR mainly attempts to reduce the time we spend trying to perceive the world after each action execution. Concretely, it makes the following changes:
- Get rid of/reduce a bunch of `time.sleep()` calls
- Minimize the number of times that we pull images off of each of the spot cameras (the API call to do this can be somewhat slow)
- Instead of querying DETIC-SAM one image at a time, batch all our queries together (required changes to the model server that can be seen [here](https://github.com/bdaiinstitute/detic-sam/tree/add-scores-to-output)

Preliminary testing reveals that the robot now spends ~10s on perception when previously it used to spend ~30+.

We can further improve speed on the server side by caching CLIP embeddings based on input text, but this is unlikely to yield too much more of a speedup (further profiling should help identify other areas for potential optimization!).