### PR TITLE
Adding Pick From Floor to Integration Tests

### DIFF
--- a/predicators/spot_utils/integration_tests.py
+++ b/predicators/spot_utils/integration_tests.py
@@ -2,8 +2,8 @@
 
 Run with --spot_robot_ip and any other flags.
 """
-from typing import Optional
 from pathlib import Path
+from typing import Optional
 
 import numpy as np
 from bosdyn.client import create_standard_sdk, math_helpers
@@ -68,19 +68,17 @@ def test_find_move_pick_place(
     if init_surface_id is not None:
         # Navigate to the first surface.
         rel_pose = get_relative_se2_from_se3(robot_pose,
-                                            detections[init_surface_id],
-                                            pre_pick_nav_distance,
-                                            pre_pick_nav_angle)
+                                             detections[init_surface_id],
+                                             pre_pick_nav_distance,
+                                             pre_pick_nav_angle)
         navigate_to_relative_pose(robot, rel_pose)
         localizer.localize()
     else:
         # In this case, we assume the object is on the floor.
-        # TODO: the pre pick nav distance is too close if the object
-        # is on the floor
         rel_pose = get_relative_se2_from_se3(robot_pose,
-                                            detections[manipuland_id],
-                                            pre_pick_nav_distance,
-                                            pre_pick_nav_angle)
+                                             detections[manipuland_id],
+                                             pre_pick_nav_distance + 0.5,
+                                             pre_pick_nav_angle)
         navigate_to_relative_pose(robot, rel_pose)
         localizer.localize()
 
@@ -98,8 +96,7 @@ def test_find_move_pick_place(
                                                    hand_camera)
 
     # Pick at the pixel with a top-down grasp.
-    top_down_rot = math_helpers.Quat.from_pitch(np.pi / 2)
-    grasp_at_pixel(robot, rgbds[hand_camera], pixel, grasp_rot=top_down_rot)
+    grasp_at_pixel(robot, rgbds[hand_camera], pixel)
     localizer.localize()
 
     # Stow the arm.
@@ -109,9 +106,9 @@ def test_find_move_pick_place(
     if target_surface_id is not None:
         robot_pose = localizer.get_last_robot_pose()
         rel_pose = get_relative_se2_from_se3(robot_pose,
-                                            detections[target_surface_id],
-                                            pre_place_nav_distance,
-                                            pre_place_nav_angle)
+                                             detections[target_surface_id],
+                                             pre_place_nav_distance,
+                                             pre_place_nav_angle)
         navigate_to_relative_pose(robot, rel_pose)
         localizer.localize()
 
@@ -160,24 +157,23 @@ def test_all_find_move_pick_place() -> None:
     cube = AprilTagObjectDetectionID(
         410, math_helpers.SE3Pose(0.0, 0.0, 0.0, math_helpers.Quat()))
 
-    # # Assume that the tables are at the "front" of the room (with the hall
-    # # on the left when on the fourth floor).
-    # input("Set up the tables and CUBE on the north wall")
-    # test_find_move_pick_place(robot, localizer, cube, init_surface,
-    #                           target_surface)
+    # Assume that the tables are at the "front" of the room (with the hall
+    # on the left when on the fourth floor).
+    input("Set up the tables and CUBE on the north wall")
+    test_find_move_pick_place(robot, localizer, cube, init_surface,
+                              target_surface)
 
-    # # Run test with brush.
-    # # Assume that the tables are at the "front" of the room (with the hall
-    # # on the left when on the fourth floor).
-    # brush = LanguageObjectDetectionID("brush")
-    # input("Set up the tables and BRUSH on the north wall")
-    # test_find_move_pick_place(robot, localizer, cube, init_surface,
-    #                           target_surface)
+    # Run test with brush.
+    # Assume that the tables are at the "front" of the room (with the hall
+    # on the left when on the fourth floor).
+    brush = LanguageObjectDetectionID("brush")
+    input("Set up the tables and BRUSH on the north wall")
+    test_find_move_pick_place(robot, localizer, brush, init_surface,
+                              target_surface)
 
     # Run test with cube on floor.
     input("Place the cube anywhere on the floor")
-    test_find_move_pick_place(robot, localizer, cube, None,
-                              target_surface)
+    test_find_move_pick_place(robot, localizer, cube, None, target_surface)
 
     # Run test with tables moved so that the init table is on the wall adjacent
     # to the hallway and the target table is on the opposite wall.

--- a/predicators/spot_utils/integration_tests.py
+++ b/predicators/spot_utils/integration_tests.py
@@ -112,12 +112,14 @@ def test_find_move_pick_place(
         navigate_to_relative_pose(robot, rel_pose)
         localizer.localize()
 
-    # Place on the surface.
-    robot_pose = localizer.get_last_robot_pose()
-    surface_rel_pose = robot_pose.inverse() * detections[target_surface_id]
-    place_rel_pos = math_helpers.Vec3(x=surface_rel_pose.x,
-                                      y=surface_rel_pose.y,
-                                      z=surface_rel_pose.z + place_offset_z)
+        # Place on the surface.
+        robot_pose = localizer.get_last_robot_pose()
+        surface_rel_pose = robot_pose.inverse() * detections[target_surface_id]
+        place_rel_pos = math_helpers.Vec3(x=surface_rel_pose.x,
+                                        y=surface_rel_pose.y,
+                                        z=surface_rel_pose.z + place_offset_z)
+
+    # TODO: Make and test a placement just onto the floor.
     place_at_relative_position(robot, place_rel_pos)
 
     # Finish by stowing arm again.

--- a/predicators/spot_utils/integration_tests.py
+++ b/predicators/spot_utils/integration_tests.py
@@ -38,7 +38,8 @@ def test_find_move_pick_place(
     manipuland_id: ObjectDetectionID,
     init_surface_id: Optional[ObjectDetectionID],
     target_surface_id: ObjectDetectionID,
-    pre_pick_nav_distance: float = 1.25,
+    pre_pick_surface_nav_distance: float = 1.25,
+    pre_pick_floor_nav_distance: float = 1.75,
     pre_place_nav_distance: float = 1.0,
     pre_pick_nav_angle: float = -np.pi / 2,
     pre_place_nav_angle: float = -np.pi / 2,
@@ -59,8 +60,7 @@ def test_find_move_pick_place(
     object_ids = [manipuland_id]
     if init_surface_id is not None:
         object_ids.append(init_surface_id)
-    if target_surface_id is not None:
-        object_ids.append(target_surface_id)
+    object_ids.append(target_surface_id)
     detections, _ = find_objects(robot, localizer, object_ids)
 
     # Get current robot pose.
@@ -69,7 +69,7 @@ def test_find_move_pick_place(
         # Navigate to the first surface.
         rel_pose = get_relative_se2_from_se3(robot_pose,
                                              detections[init_surface_id],
-                                             pre_pick_nav_distance,
+                                             pre_pick_surface_nav_distance,
                                              pre_pick_nav_angle)
         navigate_to_relative_pose(robot, rel_pose)
         localizer.localize()
@@ -77,7 +77,7 @@ def test_find_move_pick_place(
         # In this case, we assume the object is on the floor.
         rel_pose = get_relative_se2_from_se3(robot_pose,
                                              detections[manipuland_id],
-                                             pre_pick_nav_distance + 0.5,
+                                             pre_pick_floor_nav_distance,
                                              pre_pick_nav_angle)
         navigate_to_relative_pose(robot, rel_pose)
         localizer.localize()

--- a/predicators/spot_utils/integration_tests.py
+++ b/predicators/spot_utils/integration_tests.py
@@ -37,7 +37,7 @@ def test_find_move_pick_place(
     localizer: SpotLocalizer,
     manipuland_id: ObjectDetectionID,
     init_surface_id: Optional[ObjectDetectionID],
-    target_surface_id: Optional[ObjectDetectionID],
+    target_surface_id: ObjectDetectionID,
     pre_pick_nav_distance: float = 1.25,
     pre_place_nav_distance: float = 1.0,
     pre_pick_nav_angle: float = -np.pi / 2,
@@ -103,23 +103,20 @@ def test_find_move_pick_place(
     stow_arm(robot)
 
     # Navigate to the other surface.
-    if target_surface_id is not None:
-        robot_pose = localizer.get_last_robot_pose()
-        rel_pose = get_relative_se2_from_se3(robot_pose,
-                                             detections[target_surface_id],
-                                             pre_place_nav_distance,
-                                             pre_place_nav_angle)
-        navigate_to_relative_pose(robot, rel_pose)
-        localizer.localize()
+    robot_pose = localizer.get_last_robot_pose()
+    rel_pose = get_relative_se2_from_se3(robot_pose,
+                                         detections[target_surface_id],
+                                         pre_place_nav_distance,
+                                         pre_place_nav_angle)
+    navigate_to_relative_pose(robot, rel_pose)
+    localizer.localize()
 
-        # Place on the surface.
-        robot_pose = localizer.get_last_robot_pose()
-        surface_rel_pose = robot_pose.inverse() * detections[target_surface_id]
-        place_rel_pos = math_helpers.Vec3(x=surface_rel_pose.x,
-                                        y=surface_rel_pose.y,
-                                        z=surface_rel_pose.z + place_offset_z)
-
-    # TODO: Make and test a placement just onto the floor.
+    # Place on the surface.
+    robot_pose = localizer.get_last_robot_pose()
+    surface_rel_pose = robot_pose.inverse() * detections[target_surface_id]
+    place_rel_pos = math_helpers.Vec3(x=surface_rel_pose.x,
+                                      y=surface_rel_pose.y,
+                                      z=surface_rel_pose.z + place_offset_z)
     place_at_relative_position(robot, place_rel_pos)
 
     # Finish by stowing arm again.

--- a/predicators/spot_utils/spot_localization.py
+++ b/predicators/spot_utils/spot_localization.py
@@ -72,7 +72,7 @@ class SpotLocalizer:
                     initial_guess_localization=localization,
                     ko_tform_body=current_odom_tform_body)
                 break
-            except (ResponseError, TimedOutError):
+            except (ResponseError, TimedOutError) as e:
                 # Retry or fail.
                 if r == NUM_LOCALIZATION_RETRIES:
                     msg = f"Localization failed permanently: {e}."
@@ -157,7 +157,6 @@ class SpotLocalizer:
             return self.localize(num_retries=num_retries - 1,
                                  retry_wait_time=retry_wait_time)
         logging.info("Localization succeeded.")
-        self._map_initialized = True
         self._robot_pose = math_helpers.SE3Pose.from_proto(transform)
         return None
 

--- a/predicators/spot_utils/spot_localization.py
+++ b/predicators/spot_utils/spot_localization.py
@@ -121,7 +121,7 @@ class SpotLocalizer:
         It's good practice to call this periodically to avoid drift
         issues. April tags need to be in view.
         """
-        global _MAP_INITIALIZED
+        global _MAP_INITIALIZED  # pylint: disable=global-statement
         robot_state = get_robot_state(self._robot)
         current_odom_tform_body = get_odom_tform_body(
             robot_state.kinematic_state.transforms_snapshot).to_proto()


### PR DESCRIPTION
Adds a test for picking from floor to the integration tests file.

Also:
- Puts back in the call to `set_localization()` in the localization file because it turns out this is necessary at robot startup
- Removes the top-down grasp constraint from picking the object during the integration test because this was causing issues with picking from floor.