### PR TITLE
create non-degenerate sampler for sweeping

### DIFF
--- a/predicators/cogman.py
+++ b/predicators/cogman.py
@@ -66,10 +66,10 @@ class CogMan:
                 state, self._current_env_task)
             self._episode_images.extend(imgs)
 
-            # TODO
-            import cv2
-            cv2.imshow("debug", imgs[0])
-            cv2.waitKey(0)
+            # Uncomment for live visualization.
+            # import cv2
+            # cv2.imshow("debug", imgs[0])
+            # cv2.waitKey(0)
 
         # Replace the first step because the state was already added in reset().
         if not self._episode_action_history:

--- a/predicators/cogman.py
+++ b/predicators/cogman.py
@@ -65,6 +65,12 @@ class CogMan:
             imgs = self._perceiver.render_mental_images(
                 state, self._current_env_task)
             self._episode_images.extend(imgs)
+
+            # TODO
+            import cv2
+            cv2.imshow("debug", imgs[0])
+            cv2.waitKey(0)
+
         # Replace the first step because the state was already added in reset().
         if not self._episode_action_history:
             self._episode_state_history[0] = state

--- a/predicators/envs/spot_env.py
+++ b/predicators/envs/spot_env.py
@@ -1367,7 +1367,6 @@ def _dry_simulate_place_on_top(
     # a proof-of-concept for dry running spot environments.
 
     static_feats = load_spot_metadata()["static-object-features"]
-    surface_radius = static_feats[target_surface.name]["length"] / 2
     surface_height = static_feats[target_surface.name]["height"]
     held_obj_height = static_feats[held_obj.name]["height"]
     surface_pose = objects_in_view[target_surface]

--- a/predicators/envs/spot_env.py
+++ b/predicators/envs/spot_env.py
@@ -954,10 +954,10 @@ def _blocking_classifier(state: State, objects: Sequence[Object]) -> bool:
     blocked_robot_line = utils.LineSegment(robot_home_x, robot_home_y,
                                            blocked_x, blocked_y)
 
-    # Don't put the draggable blocker on the robot, even if it's held,
-    # because we don't want to consider the blocker to be unblocked until it's
-    # actually moved out of the way and released by the robot. Otherwise the
-    # robot might just pick something up and put it back down.
+    # Don't put the blocker on the robot, even if it's held, because we don't
+    # want to consider the blocker to be unblocked until it's actually moved
+    # out of the way and released by the robot. Otherwise the robot might just
+    # pick something up and put it back down, thinking it's unblocked.
     blocker_geom = _object_to_top_down_geom(blocker_obj,
                                             state,
                                             put_on_robot_if_held=False)

--- a/predicators/envs/spot_env.py
+++ b/predicators/envs/spot_env.py
@@ -1502,7 +1502,7 @@ def _dry_simulate_sweep_into_container(
     # NOTE: this may change soon to be more physically realistic.
     # If the sweep parameters are close enough to optimal, the object should
     # end up in the container.
-    optimal_dx, optimal_dy = 0.0, 0.25
+    optimal_dx, optimal_dy = 0.0, -0.5
     thresh = 0.5
     if abs(start_dx - optimal_dx) + abs(start_dy - optimal_dy) < thresh:
         x = container_pose.x

--- a/predicators/envs/spot_env.py
+++ b/predicators/envs/spot_env.py
@@ -806,6 +806,15 @@ def _on_classifier(state: State, objects: Sequence[Object]) -> bool:
     return classification_val
 
 
+def _above_classifier(state: State, objects: Sequence[Object]) -> bool:
+    obj1, obj2 = objects
+
+    bottom1 = state.get(obj1, "z") - state.get(obj1, "height") / 2
+    top2 = state.get(obj2, "z") + state.get(obj2, "height") / 2
+
+    return bottom1 > top2
+
+
 def _inside_classifier(state: State, objects: Sequence[Object]) -> bool:
     obj_in, obj_container = objects
 
@@ -969,6 +978,8 @@ _NEq = Predicate("NEq", [_base_object_type, _base_object_type],
                  _neq_classifier)
 _On = Predicate("On", [_movable_object_type, _base_object_type],
                 _on_classifier)
+_Above = Predicate("Above", [_base_object_type, _base_object_type],
+                   _above_classifier)
 _Inside = Predicate("Inside", [_movable_object_type, _base_object_type],
                     _inside_classifier)
 # NOTE: currently disabling inside predicate check because we don't have a good
@@ -1180,6 +1191,7 @@ def _create_operators() -> Iterator[STRIPSOperator]:
     parameters = [robot, container, target]
     preconds = {
         LiftedAtom(_Holding, [robot, container]),
+        LiftedAtom(_Above, [target, container]),
     }
     add_effs = {
         LiftedAtom(_ContainerReadyForSweeping, [container, target]),
@@ -1518,6 +1530,7 @@ class SpotCubeEnv(SpotRearrangementEnv):
             _InHandView,
             _Blocking,
             _NotBlocked,
+            _Above,
         }
 
     @property
@@ -1533,6 +1546,7 @@ class SpotCubeEnv(SpotRearrangementEnv):
             _Reachable,
             _Blocking,
             _NotBlocked,
+            _Above,
         }
 
     @property
@@ -1678,6 +1692,7 @@ class SpotSodaTableEnv(SpotRearrangementEnv):
             _InHandView,
             _Blocking,
             _NotBlocked,
+            _Above,
         }
 
     @property
@@ -1693,6 +1708,7 @@ class SpotSodaTableEnv(SpotRearrangementEnv):
             _Reachable,
             _Blocking,
             _NotBlocked,
+            _Above,
         }
 
     @property
@@ -1775,6 +1791,7 @@ class SpotSodaBucketEnv(SpotRearrangementEnv):
             _Reachable,
             _InHandView,
             _Inside,
+            _Above,
             _Blocking,
             _NotBlocked,
         }
@@ -1788,6 +1805,7 @@ class SpotSodaBucketEnv(SpotRearrangementEnv):
             _HandEmpty,
             _Holding,
             _On,
+            _Above,
             _Reachable,
             _InHandView,
             _Blocking,
@@ -1876,6 +1894,7 @@ class SpotSodaChairEnv(SpotRearrangementEnv):
             _Reachable,
             _InHandView,
             _Inside,
+            _Above,
             _Blocking,
             _NotBlocked,
         }
@@ -1889,6 +1908,7 @@ class SpotSodaChairEnv(SpotRearrangementEnv):
             _HandEmpty,
             _Holding,
             _On,
+            _Above,
             _Reachable,
             _InHandView,
             _Blocking,
@@ -1996,6 +2016,7 @@ class SpotSodaSweepEnv(SpotRearrangementEnv):
             _Reachable,
             _InHandView,
             _Inside,
+            _Above,
             _Blocking,
             _NotBlocked,
             _ContainerReadyForSweeping,
@@ -2013,6 +2034,7 @@ class SpotSodaSweepEnv(SpotRearrangementEnv):
             _Reachable,
             _InHandView,
             _Inside,
+            _Above,
             _Blocking,
             _NotBlocked,
             _ContainerReadyForSweeping,
@@ -2185,6 +2207,7 @@ class SpotBrushShelfEnv(SpotRearrangementEnv):
             _Reachable,
             _InHandView,
             _Inside,
+            _Above,
             _Blocking,
             _NotBlocked,
         }
@@ -2282,6 +2305,7 @@ class SpotBallAndCupStickyTableEnv(SpotRearrangementEnv):
             _InView,
             _InHandView,
             _Inside,
+            _Above,
         }
 
     @property
@@ -2297,6 +2321,7 @@ class SpotBallAndCupStickyTableEnv(SpotRearrangementEnv):
             _InView,
             _InHandView,
             _Inside,
+            _Above,
         }
 
     @property

--- a/predicators/ground_truth_models/spot_env/nsrts.py
+++ b/predicators/ground_truth_models/spot_env/nsrts.py
@@ -9,6 +9,7 @@ from predicators.envs import get_or_create_env
 from predicators.envs.spot_env import SpotRearrangementEnv, \
     _movable_object_type, _object_to_top_down_geom, get_allowed_map_regions
 from predicators.ground_truth_models import GroundTruthNSRTFactory
+from predicators.settings import CFG
 from predicators.spot_utils.utils import _Geom2D, get_spot_home_pose, \
     sample_move_offset_from_target, spot_pose_to_geom2d
 from predicators.structs import NSRT, Array, GroundAtom, NSRTSampler, Object, \
@@ -144,8 +145,12 @@ def _sweep_into_container_sampler(state: State, goal: Set[GroundAtom],
                                   rng: np.random.Generator,
                                   objs: Sequence[Object]) -> Array:
     # Parameters are start dx, start dy.
-    del state, goal, objs, rng  # randomization coming soon
-    return np.array([0.0, 0.25])
+    # NOTE: these parameters may change (need to experiment on robot).
+    del state, goal, objs
+    if CFG.spot_use_perfect_samplers:
+        return np.array([0.0, 0.25])
+    dx, dy = rng.uniform(-0.5, 0.5, size=2)
+    return np.array([dx, dy])
 
 
 def _prepare_sweeping_sampler(state: State, goal: Set[GroundAtom],

--- a/predicators/settings.py
+++ b/predicators/settings.py
@@ -643,6 +643,9 @@ class GlobalSettings:
     grammar_search_expected_nodes_allow_noops = True
     grammar_search_classifier_pretty_str_names = ["?x", "?y", "?z"]
 
+    # grammar search clustering algorithm parameters
+    grammar_search_clustering_gmm_num_components = 10
+
     @classmethod
     def get_arg_specific_settings(cls, args: Dict[str, Any]) -> Dict[str, Any]:
         """A workaround for global settings that are derived from the
@@ -670,7 +673,7 @@ class GlobalSettings:
                     # the horizon to be shorter.
                     "touch_point": 15,
                     # Ditto for the simple grid row environment.
-                    "grid_row": cls.grid_row_num_cells + 5,
+                    "grid_row": cls.grid_row_num_cells + 2,
                 })[args.get("env", "")],
 
             # Maximum number of steps to roll out an option policy.

--- a/predicators/settings.py
+++ b/predicators/settings.py
@@ -174,6 +174,7 @@ class GlobalSettings:
     spot_graph_nav_map = "floor8-v2"
     spot_grasp_stow_volume_threshold = 0.1
     spot_run_dry = False
+    spot_use_perfect_samplers = False  # for debugging
 
     # pddl blocks env parameters
     pddl_blocks_procedural_train_min_num_blocks = 3
@@ -642,9 +643,6 @@ class GlobalSettings:
     grammar_search_expected_nodes_allow_noops = True
     grammar_search_classifier_pretty_str_names = ["?x", "?y", "?z"]
 
-    # grammar search clustering algorithm parameters
-    grammar_search_clustering_gmm_num_components = 10
-
     @classmethod
     def get_arg_specific_settings(cls, args: Dict[str, Any]) -> Dict[str, Any]:
         """A workaround for global settings that are derived from the
@@ -672,7 +670,7 @@ class GlobalSettings:
                     # the horizon to be shorter.
                     "touch_point": 15,
                     # Ditto for the simple grid row environment.
-                    "grid_row": cls.grid_row_num_cells + 2,
+                    "grid_row": cls.grid_row_num_cells + 5,
                 })[args.get("env", "")],
 
             # Maximum number of steps to roll out an option policy.

--- a/predicators/spot_utils/graph_nav_maps/floor8-v2/metadata.yaml
+++ b/predicators/spot_utils/graph_nav_maps/floor8-v2/metadata.yaml
@@ -64,16 +64,19 @@ static-object-features:
     height: 0.083
     length: 0.083
     width: 0.083
+    placeable: 1  # true, can be placed
   plunger:
     shape: 1  # cuboid
     height: 0.1
     length: 0.1
     width: 0.1
+    placeable: 1
   soda_can:
     shape: 2
     height: 0.114
     length: 0.065
     width: 0.065
+    placeable: 1
   floor:
     shape: 1
     height: 0.0001
@@ -94,13 +97,16 @@ static-object-features:
     height: 0.1
     length: 0.2
     width: 0.1
+    placeable: 1
   bucket:
     shape: 2
     height: 0.4
     width: 0.23
     length: 0.23
+    placeable: 1
   chair:
     shape: 2
     height: 0.8
     length: 0.5
     width: 0.5
+    placeable: 0  # false, can't be placed

--- a/predicators/spot_utils/graph_nav_maps/floor8-v2/metadata.yaml
+++ b/predicators/spot_utils/graph_nav_maps/floor8-v2/metadata.yaml
@@ -54,11 +54,13 @@ static-object-features:
     height: 0.52
     length: 0.51
     width: 0.51
+    flat_top_surface: 1
   sticky_table:
     shape: 2  # cylinder
     height: 0.52
     length: 0.51
     width: 0.51
+    flat_top_surface: 1
   cube:
     shape: 1  # cuboid
     height: 0.083
@@ -82,16 +84,19 @@ static-object-features:
     height: 0.0001
     length: 10000000  # effectively infinite
     width: 10000000
+    flat_top_surface: 0
   white-table:
     shape: 1
     height: 0.74
     length: 1.07
     width: 0.51
+    flat_top_surface: 1
   shelf1:
     shape: 1
     height: 0.1
     length: 0.4
     width: 0.2
+    flat_top_surface: 0
   brush:
     shape: 1
     height: 0.1

--- a/tests/envs/test_spot_envs.py
+++ b/tests/envs/test_spot_envs.py
@@ -31,6 +31,7 @@ def test_spot_env_dry_run(env) -> None:
         "seed": 123,
         "spot_run_dry": True,
         "bilevel_plan_without_sim": True,
+        "spot_use_perfect_samplers": True,
     })
     env = create_new_env(env)
     perceiver = SpotPerceiver()


### PR DESCRIPTION
also refactor the predicates, types, etc. so that there's a lot less redundancy in the spot env subclasses.

example:
```
python predicators/main.py --env spot_soda_sweep_env --approach spot_wrapper[oracle] --bilevel_plan_without_sim True --num_train_tasks 0 --num_test_tasks 1  --perceiver spot_perceiver --seed 123 --execution_monitor expected_atoms --spot_run_dry True --make_cogman_videos
```


https://github.com/bdaiinstitute/predicators/assets/135051706/9d23aa1f-880f-4238-9ea1-d0605e58e5fe

