### PR TITLE
Fix option saving and loading

### DIFF
--- a/predicators/ground_truth_models/spot_env/__init__.py
+++ b/predicators/ground_truth_models/spot_env/__init__.py
@@ -1,8 +1,8 @@
 """Ground-truth models for the Spot Grocery Env."""
 
-from .nsrts import SpotCubeEnvGroundTruthNSRTFactory
-from .options import SpotCubeEnvGroundTruthOptionFactory
+from .nsrts import SpotEnvsGroundTruthNSRTFactory
+from .options import SpotEnvsGroundTruthOptionFactory
 
 __all__ = [
-    "SpotCubeEnvGroundTruthOptionFactory", "SpotCubeEnvGroundTruthNSRTFactory"
+    "SpotEnvsGroundTruthOptionFactory", "SpotEnvsGroundTruthNSRTFactory"
 ]

--- a/predicators/ground_truth_models/spot_env/nsrts.py
+++ b/predicators/ground_truth_models/spot_env/nsrts.py
@@ -207,7 +207,7 @@ def _prepare_sweeping_sampler(state: State, goal: Set[GroundAtom],
     return np.array([-0.8, -0.4, home_pose.angle])
 
 
-class SpotCubeEnvGroundTruthNSRTFactory(GroundTruthNSRTFactory):
+class SpotEnvsGroundTruthNSRTFactory(GroundTruthNSRTFactory):
     """Ground-truth NSRTs for the Spot Env."""
 
     @classmethod

--- a/predicators/ground_truth_models/spot_env/options.py
+++ b/predicators/ground_truth_models/spot_env/options.py
@@ -543,7 +543,7 @@ class _SpotParameterizedOption(utils.SingletonParameterizedOption):
         policy = _OPERATOR_NAME_TO_POLICY[operator_name]
         super().__init__(operator_name, policy, types, params_space)
 
-    def __reduce__(self):
+    def __reduce__(self) -> Tuple:
         return (_SpotParameterizedOption, (self.name, self.types))
 
 

--- a/predicators/ground_truth_models/spot_env/options.py
+++ b/predicators/ground_truth_models/spot_env/options.py
@@ -1,6 +1,6 @@
 """Ground-truth options for PDDL environments."""
 
-from typing import Any, Callable, Dict, List, Optional, Sequence, Set, Tuple
+from typing import Callable, Dict, List, Optional, Sequence, Set, Tuple
 
 import numpy as np
 from bosdyn.client import math_helpers

--- a/predicators/ground_truth_models/spot_env/options.py
+++ b/predicators/ground_truth_models/spot_env/options.py
@@ -561,7 +561,6 @@ class _SpotParameterizedOption(utils.SingletonParameterizedOption):
         return (_SpotParameterizedOption, (self.name, self.types))
 
 
-
 class SpotEnvsGroundTruthOptionFactory(GroundTruthOptionFactory):
     """Ground-truth options for Spot environments."""
 

--- a/predicators/ground_truth_models/spot_env/options.py
+++ b/predicators/ground_truth_models/spot_env/options.py
@@ -543,20 +543,6 @@ class _SpotParameterizedOption(utils.SingletonParameterizedOption):
         policy = _OPERATOR_NAME_TO_POLICY[operator_name]
         super().__init__(operator_name, policy, types, params_space)
 
-    # def __getnewargs__(self) -> Tuple:
-    #     """Avoid pickling issues with bosdyn functions."""
-    #     return (self.name, self.types)
-
-    # def __getstate__(self) -> Dict:
-    #     """Avoid pickling issues with bosdyn functions."""
-    #     return {"name": self.name}
-
-    # def __new__(cls, operator_name: str, types: List[Type]):
-    #     """Load options properly given how we're pickling."""
-    #     params_space = _OPERATOR_NAME_TO_PARAM_SPACE[operator_name]
-    #     policy = _OPERATOR_NAME_TO_POLICY[operator_name]
-    #     super().__init__(operator_name, policy, types, params_space)
-
     def __reduce__(self):
         return (_SpotParameterizedOption, (self.name, self.types))
 

--- a/predicators/ground_truth_models/spot_env/options.py
+++ b/predicators/ground_truth_models/spot_env/options.py
@@ -1,6 +1,6 @@
 """Ground-truth options for PDDL environments."""
 
-from typing import Callable, Dict, List, Optional, Sequence, Set, Tuple
+from typing import Any, Callable, Dict, List, Optional, Sequence, Set, Tuple
 
 import numpy as np
 from bosdyn.client import math_helpers
@@ -543,16 +543,26 @@ class _SpotParameterizedOption(utils.SingletonParameterizedOption):
         policy = _OPERATOR_NAME_TO_POLICY[operator_name]
         super().__init__(operator_name, policy, types, params_space)
 
-    def __getnewargs__(self) -> Tuple:
-        """Avoid pickling issues with bosdyn functions."""
-        return (self.name, self.types)
+    # def __getnewargs__(self) -> Tuple:
+    #     """Avoid pickling issues with bosdyn functions."""
+    #     return (self.name, self.types)
 
-    def __getstate__(self) -> Dict:
-        """Avoid pickling issues with bosdyn functions."""
-        return {"name": self.name}
+    # def __getstate__(self) -> Dict:
+    #     """Avoid pickling issues with bosdyn functions."""
+    #     return {"name": self.name}
+
+    # def __new__(cls, operator_name: str, types: List[Type]):
+    #     """Load options properly given how we're pickling."""
+    #     params_space = _OPERATOR_NAME_TO_PARAM_SPACE[operator_name]
+    #     policy = _OPERATOR_NAME_TO_POLICY[operator_name]
+    #     super().__init__(operator_name, policy, types, params_space)
+
+    def __reduce__(self):
+        return (_SpotParameterizedOption, (self.name, self.types))
 
 
-class SpotCubeEnvGroundTruthOptionFactory(GroundTruthOptionFactory):
+
+class SpotEnvsGroundTruthOptionFactory(GroundTruthOptionFactory):
     """Ground-truth options for Spot environments."""
 
     @classmethod


### PR DESCRIPTION
Fixes option saving and loading for the `_SpotParameterizedOptions` so that we can save, restart, and eval online learning at any intermediate cycle!
Also renames the option and NSRT factories to remove the `Cube` from them, since that's deprecated.