### PR TITLE
don't actively reconstruct the state except at the very beginning for real spot env

### DIFF
--- a/predicators/envs/spot_env.py
+++ b/predicators/envs/spot_env.py
@@ -309,6 +309,12 @@ class SpotRearrangementEnv(BaseEnv):
             self._current_task = self._test_tasks[task_idx]
         elif CFG.spot_run_dry:
             self._current_task = self._get_dry_task(train_or_test, task_idx)
+        elif self._current_observation is not None:
+            # For the real spot environment, only actively construct the state
+            # once, at the very beginning (or on loading, if needed).
+            goal_description = self._generate_goal_description()
+            self._current_task = EnvironmentTask(self._current_observation,
+                                                 goal_description)
         else:
             prompt = f"Please set up {train_or_test} task {task_idx}!"
             utils.prompt_user(prompt)

--- a/predicators/settings.py
+++ b/predicators/settings.py
@@ -170,7 +170,7 @@ class GlobalSettings:
     # SpotEnv parameters
     spot_robot_ip = "invalid-IP-address"
     spot_fiducial_size = 44.45
-    spot_vision_detection_threshold = 0.3
+    spot_vision_detection_threshold = 0.5
     spot_perception_outdir = "spot_perception_outputs"
     spot_render_perception_outputs = True
     spot_graph_nav_map = "floor8-v2"

--- a/predicators/spot_utils/graph_nav_maps/floor8-cup-table/metadata.yaml
+++ b/predicators/spot_utils/graph_nav_maps/floor8-cup-table/metadata.yaml
@@ -57,7 +57,7 @@ static-object-features:
   drafting_table:
     shape: 1  # cuboid
     height: 0.45
-    length: 0.35
+    length: 0.3
     width: 0.6
     flat_top_surface: 1
     placeable: 1  # true, can be placed

--- a/predicators/spot_utils/graph_nav_maps/floor8-cup-table/metadata.yaml
+++ b/predicators/spot_utils/graph_nav_maps/floor8-cup-table/metadata.yaml
@@ -44,7 +44,7 @@ known-immovable-objects:
     z: -0.1
   drafting_table:
     x: 2.5
-    y: 2.5
+    y: 2.7
     z: -0.25
 # Static object features, including the shapes and sizes of known objects.
 static-object-features:

--- a/predicators/spot_utils/graph_nav_maps/floor8-cup-table/metadata.yaml
+++ b/predicators/spot_utils/graph_nav_maps/floor8-cup-table/metadata.yaml
@@ -44,7 +44,7 @@ known-immovable-objects:
     z: -0.1
   drafting_table:
     x: 2.5
-    y: 2.65
+    y: 2.5
     z: -0.25
 # Static object features, including the shapes and sizes of known objects.
 static-object-features:


### PR DESCRIPTION
also update vision detection threshold and table length