### PR TITLE
fix a few issues with sweep two objects and saving models

### DIFF
--- a/predicators/approaches/active_sampler_learning_approach.py
+++ b/predicators/approaches/active_sampler_learning_approach.py
@@ -262,7 +262,7 @@ class ActiveSamplerLearningApproach(OnlineNSRTLearningApproach):
         for ground_op, model in self._competence_models.items():
             approach_save_path = utils.get_approach_save_path_str()
             save_path = "_".join([
-                approach_save_path, f"{ground_op.name}{ground_op.objects}",
+                approach_save_path, ground_op.short_str,
                 f"{self._online_learning_cycle}.competence"
             ])
             with open(save_path, "wb") as f:

--- a/predicators/envs/spot_env.py
+++ b/predicators/envs/spot_env.py
@@ -1505,6 +1505,7 @@ def _create_operators() -> Iterator[STRIPSOperator]:
     container = Variable("?container", _container_type)
     parameters = [robot, sweeper, target1, target2, surface, container]
     preconds = {
+        LiftedAtom(_NEq, [target1, target2]),
         LiftedAtom(_NotBlocked, [target1]),
         LiftedAtom(_NotBlocked, [target2]),
         LiftedAtom(_Holding, [robot, sweeper]),

--- a/predicators/explorers/active_sampler_explorer.py
+++ b/predicators/explorers/active_sampler_explorer.py
@@ -415,9 +415,7 @@ class ActiveSamplerExplorer(BaseExplorer):
             # Now, we need to get the file location and the max
             # datapoint id saved at this location.
             os.makedirs(CFG.data_dir, exist_ok=True)
-            objects_tuple_str = str(tuple(nsrt.objects))
-            objects_tuple_str = objects_tuple_str.strip('()')
-            pfx = f"{CFG.data_dir}/{CFG.env}_{nsrt.name}({objects_tuple_str})_"
+            pfx = f"{CFG.data_dir}/{CFG.env}_{nsrt.short_str}_"
             filepath_template = f"{pfx}*.data"
             datapoint_id = 0
             all_saved_files = glob.glob(filepath_template)


### PR DESCRIPTION
from crash:
```
OSError: [Errno 63] File name too long: 'saved_approaches/spot_main_sweep_env__active_sampler_learning__456______spot_sweeping_sim_yogurt_only-planning_progress_explore.saved_SweepTwoObjectsIntoContainer[robot:robot, brush:movable, yogurt:movable, yogurt:movable, black_table:immovable, bucket:container]_5.competence'
```