### PR TITLE
Many changes necessary for getting 2-object sweeping task to work on supercloud

### DIFF
--- a/predicators/approaches/maple_q_approach.py
+++ b/predicators/approaches/maple_q_approach.py
@@ -64,6 +64,12 @@ class MapleQApproach(OnlineNSRTLearningApproach):
     def _solve(self, task: Task, timeout: int) -> Callable[[State], Action]:
 
         def _option_policy(state: State) -> _Option:
+            if len(self._q_function._ordered_ground_nsrts) == 0:
+                # In spot envs, all the train tasks are empty,
+                # and so the ground nsrts will be empty as well.
+                assert "spot" in CFG.env
+                self._set_grounding_from_state(state)
+                assert len(self._q_function._ordered_ground_nsrts) > 0
             return self._q_function.get_option(
                 state,
                 task.goal,
@@ -72,6 +78,46 @@ class MapleQApproach(OnlineNSRTLearningApproach):
 
         return utils.option_policy_to_policy(
             _option_policy, max_option_steps=CFG.max_num_steps_option_rollout)
+
+    def _set_grounding_from_state(self, state: State) -> None:
+        """Helper method to setup the MAPLE-Q network in the situation where
+        all the training tasks are empty originally.
+
+        This happens with spot environments.
+        """
+        all_ground_nsrts: Set[_GroundNSRT] = set()
+        if CFG.sesame_grounder == "naive":
+            for nsrt in self._nsrts:
+                all_objects = set(state)
+                all_ground_nsrts.update(
+                    utils.all_ground_nsrts(nsrt, all_objects))
+        elif CFG.sesame_grounder == "fd_translator":  # pragma: no cover
+            all_objects = set(state)
+            curr_task_types = {o.type for o in state}
+            # Ensure we crawl the type hierarchy to find all
+            # parent types.
+            parent_types = set()
+            for t in curr_task_types:
+                curr_t = t
+                while curr_t.parent is not None:
+                    parent_types.add(curr_t.parent)
+                    curr_t = curr_t.parent
+            curr_task_types |= parent_types
+            curr_init_atoms = utils.abstract(state,
+                                             self._get_current_predicates())
+            # In this case, need to consider all possible training task
+            # goals we might encounter.
+            for task in self._train_tasks:
+                all_ground_nsrts.update(
+                    utils.all_ground_nsrts_fd_translator(
+                        self._nsrts, all_objects,
+                        self._get_current_predicates(), curr_task_types,
+                        curr_init_atoms, task.goal))
+        else:  # pragma: no cover
+            raise ValueError(
+                f"Unrecognized sesame_grounder: {CFG.sesame_grounder}")
+        goals = [t.goal for t in self._train_tasks]
+        self._q_function.set_grounding(all_objects, goals, all_ground_nsrts)
 
     def _create_explorer(self) -> BaseExplorer:
         """Create a new explorer at the beginning of each interaction cycle."""

--- a/predicators/approaches/maple_q_approach.py
+++ b/predicators/approaches/maple_q_approach.py
@@ -64,12 +64,12 @@ class MapleQApproach(OnlineNSRTLearningApproach):
     def _solve(self, task: Task, timeout: int) -> Callable[[State], Action]:
 
         def _option_policy(state: State) -> _Option:
-            if len(self._q_function._ordered_ground_nsrts) == 0:
+            if len(self._q_function._ordered_ground_nsrts) == 0:  # pragma: no cover  # pylint: disable=protected-access
                 # In spot envs, all the train tasks are empty,
                 # and so the ground nsrts will be empty as well.
                 assert "spot" in CFG.env
                 self._set_grounding_from_state(state)
-                assert len(self._q_function._ordered_ground_nsrts) > 0
+                assert len(self._q_function._ordered_ground_nsrts) > 0  # pylint: disable=protected-access
             return self._q_function.get_option(
                 state,
                 task.goal,
@@ -79,7 +79,8 @@ class MapleQApproach(OnlineNSRTLearningApproach):
         return utils.option_policy_to_policy(
             _option_policy, max_option_steps=CFG.max_num_steps_option_rollout)
 
-    def _set_grounding_from_state(self, state: State) -> None:
+    def _set_grounding_from_state(self,
+                                  state: State) -> None:  # pragma: no cover
         """Helper method to setup the MAPLE-Q network in the situation where
         all the training tasks are empty originally.
 
@@ -91,7 +92,7 @@ class MapleQApproach(OnlineNSRTLearningApproach):
                 all_objects = set(state)
                 all_ground_nsrts.update(
                     utils.all_ground_nsrts(nsrt, all_objects))
-        elif CFG.sesame_grounder == "fd_translator":  # pragma: no cover
+        elif CFG.sesame_grounder == "fd_translator":
             all_objects = set(state)
             curr_task_types = {o.type for o in state}
             # Ensure we crawl the type hierarchy to find all
@@ -113,7 +114,7 @@ class MapleQApproach(OnlineNSRTLearningApproach):
                         self._nsrts, all_objects,
                         self._get_current_predicates(), curr_task_types,
                         curr_init_atoms, task.goal))
-        else:  # pragma: no cover
+        else:
             raise ValueError(
                 f"Unrecognized sesame_grounder: {CFG.sesame_grounder}")
         goals = [t.goal for t in self._train_tasks]

--- a/predicators/envs/spot_env.py
+++ b/predicators/envs/spot_env.py
@@ -1522,7 +1522,7 @@ def _create_operators() -> Iterator[STRIPSOperator]:
         # This `IsSemanticallyGreaterThan` predicate just serves to
         # provide a canonical grounding for this operator (we don't want
         # Sweep(yogurt, chips) to be separate from Sweep(chips, yogurt)).
-        LiftedAtom(_IsSemanticallyGreaterThan, target1, target2),
+        LiftedAtom(_IsSemanticallyGreaterThan, [target1, target2]),
         # Arbitrarily pick one of the targets to be the one ready for sweeping,
         # to prevent the robot 'moving to get ready for sweeping' twice.
         LiftedAtom(_RobotReadyForSweeping, [robot, target1]),

--- a/predicators/envs/spot_env.py
+++ b/predicators/envs/spot_env.py
@@ -1187,11 +1187,14 @@ def _robot_ready_for_sweeping_classifier(state: State,
     target_xy = np.array([state.get(target, "x"), state.get(target, "y")])
     return np.allclose(expected_xy, target_xy, atol=_ROBOT_SWEEP_READY_TOL)
 
-def _is_semantically_greater_than_classifier(state: State, objects: Sequence[Object]) -> bool:
+
+def _is_semantically_greater_than_classifier(
+        state: State, objects: Sequence[Object]) -> bool:
     obj1, obj2 = objects
     # Check if the name of object 1 is greater (in a Pythonic sense) than
     # that of object 2.
     return obj1.name > obj2.name
+
 
 def _get_sweeping_surface_for_container(container: Object,
                                         state: State) -> Optional[Object]:
@@ -1248,30 +1251,14 @@ _HasFlatTopSurface = Predicate("HasFlatTopSurface", [_immovable_object_type],
 _RobotReadyForSweeping = Predicate("RobotReadyForSweeping",
                                    [_robot_type, _movable_object_type],
                                    _robot_ready_for_sweeping_classifier)
-_IsSemanticallyGreaterThan = Predicate("_IsSemanticallyGreaterThan",
-                                   [_base_object_type, _base_object_type],
-                                   _is_semantically_greater_than_classifier)
+_IsSemanticallyGreaterThan = Predicate(
+    "_IsSemanticallyGreaterThan", [_base_object_type, _base_object_type],
+    _is_semantically_greater_than_classifier)
 _ALL_PREDICATES = {
-    _NEq,
-    _On,
-    _TopAbove,
-    _Inside,
-    _NotInsideAnyContainer,
-    _FitsInside,
-    _HandEmpty,
-    _Holding,
-    _NotHolding,
-    _InHandView,
-    _InView,
-    _Reachable,
-    _Blocking,
-    _NotBlocked,
-    _ContainerReadyForSweeping,
-    _IsPlaceable,
-    _IsNotPlaceable,
-    _IsSweeper,
-    _HasFlatTopSurface,
-    _RobotReadyForSweeping,
+    _NEq, _On, _TopAbove, _Inside, _NotInsideAnyContainer, _FitsInside,
+    _HandEmpty, _Holding, _NotHolding, _InHandView, _InView, _Reachable,
+    _Blocking, _NotBlocked, _ContainerReadyForSweeping, _IsPlaceable,
+    _IsNotPlaceable, _IsSweeper, _HasFlatTopSurface, _RobotReadyForSweeping,
     _IsSemanticallyGreaterThan
 }
 _NONPERCEPT_PREDICATES: Set[Predicate] = set()

--- a/predicators/envs/spot_env.py
+++ b/predicators/envs/spot_env.py
@@ -1473,10 +1473,10 @@ def _create_operators() -> Iterator[STRIPSOperator]:
         LiftedAtom(_NotHolding, [robot, blocker]),
     }
     del_effs = {
-        LiftedAtom(_Blocking, [blocker, blocked]),
+        # LiftedAtom(_Blocking, [blocker, blocked]),
         LiftedAtom(_Holding, [robot, blocker]),
     }
-    ignore_effs = {_InHandView, _Reachable, _RobotReadyForSweeping}
+    ignore_effs = {_InHandView, _Reachable, _RobotReadyForSweeping, _Blocking}
     yield STRIPSOperator("DragToUnblockObject", parameters, preconds, add_effs,
                          del_effs, ignore_effs)
 
@@ -1505,8 +1505,9 @@ def _create_operators() -> Iterator[STRIPSOperator]:
     container = Variable("?container", _container_type)
     parameters = [robot, sweeper, target1, target2, surface, container]
     preconds = {
+        # Arbitrarily pick one of the targets to be the one not blocked,
+        # to prevent the robot 'dragging to unblock' twice.
         LiftedAtom(_NotBlocked, [target1]),
-        LiftedAtom(_NotBlocked, [target2]),
         LiftedAtom(_Holding, [robot, sweeper]),
         LiftedAtom(_On, [target1, surface]),
         LiftedAtom(_On, [target2, surface]),

--- a/predicators/envs/spot_env.py
+++ b/predicators/envs/spot_env.py
@@ -279,7 +279,9 @@ class SpotRearrangementEnv(BaseEnv):
             return _dry_simulate_pick_from_top(obs, target_obj, pixel,
                                                nonpercept_atoms)
 
-        if action_name == "MoveToReachObject":
+        if action_name in [
+                "MoveToReachObject", "MoveToReadySweep", "MoveToBodyViewObject"
+        ]:
             robot_rel_se2_pose = action_args[1]
             return _dry_simulate_move_to_reach_obj(obs, robot_rel_se2_pose,
                                                    nonpercept_atoms)
@@ -339,11 +341,6 @@ class SpotRearrangementEnv(BaseEnv):
         if action_name == "DropNotPlaceableObject":
             return _dry_simulate_drop_not_placeable_object(
                 obs, nonpercept_atoms)
-
-        if action_name == "MoveToReadySweep":
-            robot_rel_se2_pose = action_args[1]
-            return _dry_simulate_move_to_reach_obj(obs, robot_rel_se2_pose,
-                                                   nonpercept_atoms)
 
         if action_name in ["find-objects", "stow-arm"]:
             return _dry_simulate_noop(obs, nonpercept_atoms)

--- a/predicators/envs/spot_env.py
+++ b/predicators/envs/spot_env.py
@@ -1218,6 +1218,7 @@ def _robot_ready_for_sweeping_classifier(state: State,
 
 def _is_semantically_greater_than_classifier(
         state: State, objects: Sequence[Object]) -> bool:
+    del state  # unused
     obj1, obj2 = objects
     # Check if the name of object 1 is greater (in a Pythonic sense) than
     # that of object 2.
@@ -1283,7 +1284,7 @@ _IsSemanticallyGreaterThan = Predicate(
     "_IsSemanticallyGreaterThan", [_base_object_type, _base_object_type],
     _is_semantically_greater_than_classifier)
 _ALL_PREDICATES = {
-    _NEq, _On, _TopAbove, _Inside, _NotInsideAnyContainer, _FitsInside,
+    _NEq, _On, _TopAbove, _Inside, _NotInsideAnyContainer, _FitsInXY,
     _HandEmpty, _Holding, _NotHolding, _InHandView, _InView, _Reachable,
     _Blocking, _NotBlocked, _ContainerReadyForSweeping, _IsPlaceable,
     _IsNotPlaceable, _IsSweeper, _HasFlatTopSurface, _RobotReadyForSweeping,

--- a/predicators/envs/spot_env.py
+++ b/predicators/envs/spot_env.py
@@ -2556,10 +2556,11 @@ class SpotMainSweepEnv(SpotRearrangementEnv):
             chair_z = floor_z + chair_height / 2
             obj_to_xyz[chair] = (chair_x, chair_y, chair_z)
 
-            # Bucket.
+            # Bucket. Note that this starts already next to the table
+            # to be conducive to sweeping.
             bucket = Object("bucket", _container_type)
-            bucket_x = robot_pose.x - 0.25
-            bucket_y = robot_pose.y - 0.5
+            bucket_x = table_x - 0.6
+            bucket_y = table_y - 0.15
             bucket_z = floor_z + bucket_height / 2
             obj_to_xyz[bucket] = (bucket_x, bucket_y, bucket_z)
 

--- a/predicators/envs/spot_env.py
+++ b/predicators/envs/spot_env.py
@@ -1473,7 +1473,6 @@ def _create_operators() -> Iterator[STRIPSOperator]:
         LiftedAtom(_NotHolding, [robot, blocker]),
     }
     del_effs = {
-        # LiftedAtom(_Blocking, [blocker, blocked]),
         LiftedAtom(_Holding, [robot, blocker]),
     }
     ignore_effs = {_InHandView, _Reachable, _RobotReadyForSweeping, _Blocking}

--- a/predicators/ground_truth_models/spot_env/nsrts.py
+++ b/predicators/ground_truth_models/spot_env/nsrts.py
@@ -46,7 +46,10 @@ def _move_offset_sampler(state: State, robot_obj: Object,
         )
     # Rare sampling failures.
     except RuntimeError:  # pragma: no cover
-        raise utils.OptionExecutionFailure("Move offset sampling failed.")
+        print("WARNING: Failed to find good movement sample.")
+        # Pick distance and angle at random.
+        distance = rng.uniform(min_dist, max_dist)
+        angle = rng.uniform(min_angle, max_angle)
 
     return np.array([distance, angle])
 

--- a/predicators/main.py
+++ b/predicators/main.py
@@ -125,7 +125,7 @@ def main() -> None:
     # Create the agent (approach).
     approach_name = CFG.approach
     # MAPLE-Q is not compatible with a wrapper.
-    if CFG.approach_wrapper and CFG.approach_name != "maple_q":
+    if CFG.approach_wrapper and approach_name != "maple_q":
         approach_name = f"{CFG.approach_wrapper}[{approach_name}]"
     approach = create_approach(approach_name, preds, options, env.types,
                                env.action_space, stripped_train_tasks)

--- a/predicators/main.py
+++ b/predicators/main.py
@@ -124,7 +124,8 @@ def main() -> None:
         options = parse_config_included_options(env)
     # Create the agent (approach).
     approach_name = CFG.approach
-    if CFG.approach_wrapper:
+    # MAPLE-Q is not compatible with a wrapper.
+    if CFG.approach_wrapper and CFG.approach_name != "maple_q":
         approach_name = f"{CFG.approach_wrapper}[{approach_name}]"
     approach = create_approach(approach_name, preds, options, env.types,
                                env.action_space, stripped_train_tasks)

--- a/predicators/ml_models.py
+++ b/predicators/ml_models.py
@@ -1391,7 +1391,6 @@ class MapleQFunction(MLPRegressor):
             self.predict_q_value(state, goal, option) for option in options
         ]
         idx = np.argmax(scores)
-        import ipdb; ipdb.set_trace()
         return options[idx]
 
     def add_datum_to_replay_buffer(self, datum: MapleQData) -> None:

--- a/predicators/ml_models.py
+++ b/predicators/ml_models.py
@@ -1391,6 +1391,7 @@ class MapleQFunction(MLPRegressor):
             self.predict_q_value(state, goal, option) for option in options
         ]
         idx = np.argmax(scores)
+        import ipdb; ipdb.set_trace()
         return options[idx]
 
     def add_datum_to_replay_buffer(self, datum: MapleQData) -> None:

--- a/scripts/configs/active_sampler_learning.yaml
+++ b/scripts/configs/active_sampler_learning.yaml
@@ -79,6 +79,7 @@ ENVS:
       active_sampler_learning_explore_length_base: 100000  # effectively disable
       active_sampler_learning_feature_selection: oracle
       spot_run_dry: True
+      approach_wrapper: spot_wrapper
       perceiver: spot_perceiver
       segmenter: spot
       active_sampler_learning_explore_pursue_goal_interval: 1
@@ -97,8 +98,6 @@ ENVS:
   #     active_sampler_learning_init_cycles_to_pursue_goal: 5
   #     spot_run_dry: True
   #     perceiver: spot_perceiver
-  #     # IMPORTANT: Comment out the below line when running the
-  #     # MAPLE-Q experiments
   #     approach_wrapper: spot_wrapper
   #     segmenter: spot
   #     max_num_steps_interaction_request: 100

--- a/scripts/configs/active_sampler_learning.yaml
+++ b/scripts/configs/active_sampler_learning.yaml
@@ -97,4 +97,4 @@ FLAGS:
   active_sampler_learning_n_iter_no_change: 5000
   spot_graph_nav_map: "floor8-sweeping"
 START_SEED: 456
-NUM_SEEDS: 10
+NUM_SEEDS: 1

--- a/scripts/configs/active_sampler_learning.yaml
+++ b/scripts/configs/active_sampler_learning.yaml
@@ -6,62 +6,62 @@ APPROACHES:
     FLAGS:
       explorer: "active_sampler"
       active_sampler_explore_task_strategy: "planning_progress"
-  task_repeat_explore:
-    NAME: "active_sampler_learning"
-    FLAGS:
-      explorer: "active_sampler"
-      active_sampler_explore_task_strategy: "task_repeat"
-  success_rate_explore_ucb:
-    NAME: "active_sampler_learning"
-    FLAGS:
-      explorer: "active_sampler"
-      active_sampler_explore_task_strategy: "success_rate"
-      active_sampler_explore_use_ucb_bonus: False
-  success_rate_explore_no_ucb:
-    NAME: "active_sampler_learning"
-    FLAGS:
-      explorer: "active_sampler"
-      active_sampler_explore_task_strategy: "success_rate"
-      active_sampler_explore_use_ucb_bonus: False
-  random_score_explore:
-    NAME: "active_sampler_learning"
-    FLAGS:
-      explorer: "active_sampler"
-      active_sampler_explore_task_strategy: "random"
-  random_nsrts_explore:
-    NAME: "active_sampler_learning"
-    FLAGS:
-      explorer: "random_nsrts"
-  maple_q:
-    NAME: "maple_q"
-    FLAGS:
-      explorer: "maple_q"
-      mlp_regressor_max_itr: 100000
-      active_sampler_learning_batch_size: 1024
+  # task_repeat_explore:
+  #   NAME: "active_sampler_learning"
+  #   FLAGS:
+  #     explorer: "active_sampler"
+  #     active_sampler_explore_task_strategy: "task_repeat"
+  # success_rate_explore_ucb:
+  #   NAME: "active_sampler_learning"
+  #   FLAGS:
+  #     explorer: "active_sampler"
+  #     active_sampler_explore_task_strategy: "success_rate"
+  #     active_sampler_explore_use_ucb_bonus: False
+  # success_rate_explore_no_ucb:
+  #   NAME: "active_sampler_learning"
+  #   FLAGS:
+  #     explorer: "active_sampler"
+  #     active_sampler_explore_task_strategy: "success_rate"
+  #     active_sampler_explore_use_ucb_bonus: False
+  # random_score_explore:
+  #   NAME: "active_sampler_learning"
+  #   FLAGS:
+  #     explorer: "active_sampler"
+  #     active_sampler_explore_task_strategy: "random"
+  # random_nsrts_explore:
+  #   NAME: "active_sampler_learning"
+  #   FLAGS:
+  #     explorer: "random_nsrts"
+  # maple_q:
+  #   NAME: "maple_q"
+  #   FLAGS:
+  #     explorer: "maple_q"
+  #     mlp_regressor_max_itr: 100000
+  #     active_sampler_learning_batch_size: 1024
 ENVS:
-  grid_row:
-    NAME: "grid_row"
-    FLAGS:
-      max_num_steps_interaction_request: 150
-      active_sampler_learning_explore_length_base: 100000  # effectively disable
-      active_sampler_learning_feature_selection: all
-      active_sampler_learning_explore_pursue_goal_interval: 1
-  ball_and_cup_sticky_table:
-    NAME: "ball_and_cup_sticky_table"
-    FLAGS:
-      sticky_table_place_smooth_fall_prob: 1.00
-      sticky_table_place_sticky_fall_prob: 0.00
-      sticky_table_pick_success_prob: 1.0
-      sticky_table_num_sticky_tables: 1
-      sticky_table_num_tables: 5
-      sticky_table_place_ball_fall_prob: 1.00
-      active_sampler_learning_explore_length_base: 25
-      active_sampler_learning_exploration_epsilon: 0.5
-      skill_competence_model_optimistic_recency_size: 2
-      skill_competence_model_optimistic_window_size: 2
-      horizon: 8
-      active_sampler_learning_explore_length_base: 100000  # effectively disable
-      active_sampler_learning_feature_selection: oracle
+  # grid_row:
+  #   NAME: "grid_row"
+  #   FLAGS:
+  #     max_num_steps_interaction_request: 150
+  #     active_sampler_learning_explore_length_base: 100000  # effectively disable
+  #     active_sampler_learning_feature_selection: all
+  #     active_sampler_learning_explore_pursue_goal_interval: 1
+  # ball_and_cup_sticky_table:
+  #   NAME: "ball_and_cup_sticky_table"
+  #   FLAGS:
+  #     sticky_table_place_smooth_fall_prob: 1.00
+  #     sticky_table_place_sticky_fall_prob: 0.00
+  #     sticky_table_pick_success_prob: 1.0
+  #     sticky_table_num_sticky_tables: 1
+  #     sticky_table_num_tables: 5
+  #     sticky_table_place_ball_fall_prob: 1.00
+  #     active_sampler_learning_explore_length_base: 25
+  #     active_sampler_learning_exploration_epsilon: 0.5
+  #     skill_competence_model_optimistic_recency_size: 2
+  #     skill_competence_model_optimistic_window_size: 2
+  #     horizon: 8
+  #     active_sampler_learning_explore_length_base: 100000  # effectively disable
+  #     active_sampler_learning_feature_selection: oracle
   spot_sweeping_sim:
     NAME: "spot_main_sweep_env"
     FLAGS:

--- a/scripts/configs/active_sampler_learning.yaml
+++ b/scripts/configs/active_sampler_learning.yaml
@@ -69,7 +69,7 @@ ENVS:
       active_sampler_learning_exploration_epsilon: 0.5
       skill_competence_model_optimistic_recency_size: 2
       skill_competence_model_optimistic_window_size: 2
-      horizon: 15
+      horizon: 10
       active_sampler_learning_explore_length_base: 100000  # effectively disable
       active_sampler_learning_feature_selection: oracle
       spot_run_dry: True

--- a/scripts/configs/active_sampler_learning.yaml
+++ b/scripts/configs/active_sampler_learning.yaml
@@ -1,42 +1,42 @@
 # Final active sampler learning experiments.
 ---
 APPROACHES:
-  # planning_progress_explore:
-  #   NAME: "active_sampler_learning"
-  #   FLAGS:
-  #     explorer: "active_sampler"
-  #     active_sampler_explore_task_strategy: "planning_progress"
-  # task_repeat_explore:
-  #   NAME: "active_sampler_learning"
-  #   FLAGS:
-  #     explorer: "active_sampler"
-  #     active_sampler_explore_task_strategy: "task_repeat"
-  # success_rate_explore_ucb:
-  #   NAME: "active_sampler_learning"
-  #   FLAGS:
-  #     explorer: "active_sampler"
-  #     active_sampler_explore_task_strategy: "success_rate"
-  #     active_sampler_explore_use_ucb_bonus: True
-  # competence_gradient_explore_ucb:
-  #   NAME: "active_sampler_learning"
-  #   FLAGS:
-  #     explorer: "active_sampler"
-  #     active_sampler_explore_task_strategy: "competence_gradient"
-  #     active_sampler_explore_use_ucb_bonus: True
-  # skill_diversity_explore_ucb:
-  #   NAME: "active_sampler_learning"
-  #   FLAGS:
-  #     explorer: "active_sampler"
-  #     active_sampler_explore_task_strategy: "skill_diversity"
-  # random_score_explore:
-  #   NAME: "active_sampler_learning"
-  #   FLAGS:
-  #     explorer: "active_sampler"
-  #     active_sampler_explore_task_strategy: "random"
-  # random_nsrts_explore:
-  #   NAME: "active_sampler_learning"
-  #   FLAGS:
-  #     explorer: "random_nsrts"
+  planning_progress_explore:
+    NAME: "active_sampler_learning"
+    FLAGS:
+      explorer: "active_sampler"
+      active_sampler_explore_task_strategy: "planning_progress"
+  task_repeat_explore:
+    NAME: "active_sampler_learning"
+    FLAGS:
+      explorer: "active_sampler"
+      active_sampler_explore_task_strategy: "task_repeat"
+  success_rate_explore_ucb:
+    NAME: "active_sampler_learning"
+    FLAGS:
+      explorer: "active_sampler"
+      active_sampler_explore_task_strategy: "success_rate"
+      active_sampler_explore_use_ucb_bonus: True
+  competence_gradient_explore_ucb:
+    NAME: "active_sampler_learning"
+    FLAGS:
+      explorer: "active_sampler"
+      active_sampler_explore_task_strategy: "competence_gradient"
+      active_sampler_explore_use_ucb_bonus: True
+  skill_diversity_explore_ucb:
+    NAME: "active_sampler_learning"
+    FLAGS:
+      explorer: "active_sampler"
+      active_sampler_explore_task_strategy: "skill_diversity"
+  random_score_explore:
+    NAME: "active_sampler_learning"
+    FLAGS:
+      explorer: "active_sampler"
+      active_sampler_explore_task_strategy: "random"
+  random_nsrts_explore:
+    NAME: "active_sampler_learning"
+    FLAGS:
+      explorer: "random_nsrts"
   maple_q:
     NAME: "maple_q"
     FLAGS:
@@ -44,30 +44,30 @@ APPROACHES:
       mlp_regressor_max_itr: 100000
       active_sampler_learning_batch_size: 1024
 ENVS:
-  # grid_row:
-  #   NAME: "grid_row"
-  #   FLAGS:
-  #     active_sampler_learning_explore_length_base: 100000  # effectively disable
-  #     active_sampler_learning_feature_selection: all
-  #     active_sampler_learning_explore_pursue_goal_interval: 1
-  #     max_num_steps_interaction_request: 150
-  # ball_and_cup_sticky_table:
-  #   NAME: "ball_and_cup_sticky_table"
-  #   FLAGS:
-  #     sticky_table_place_smooth_fall_prob: 1.00
-  #     sticky_table_place_sticky_fall_prob: 0.00
-  #     sticky_table_pick_success_prob: 1.0
-  #     sticky_table_num_sticky_tables: 1
-  #     sticky_table_num_tables: 5
-  #     sticky_table_place_ball_fall_prob: 1.00
-  #     active_sampler_learning_explore_length_base: 25
-  #     active_sampler_learning_exploration_epsilon: 0.5
-  #     skill_competence_model_optimistic_recency_size: 2
-  #     skill_competence_model_optimistic_window_size: 2
-  #     horizon: 8
-  #     active_sampler_learning_explore_length_base: 100000  # effectively disable
-  #     active_sampler_learning_feature_selection: oracle
-  #     max_num_steps_interaction_request: 100
+  grid_row:
+    NAME: "grid_row"
+    FLAGS:
+      active_sampler_learning_explore_length_base: 100000  # effectively disable
+      active_sampler_learning_feature_selection: all
+      active_sampler_learning_explore_pursue_goal_interval: 1
+      max_num_steps_interaction_request: 150
+  ball_and_cup_sticky_table:
+    NAME: "ball_and_cup_sticky_table"
+    FLAGS:
+      sticky_table_place_smooth_fall_prob: 1.00
+      sticky_table_place_sticky_fall_prob: 0.00
+      sticky_table_pick_success_prob: 1.0
+      sticky_table_num_sticky_tables: 1
+      sticky_table_num_tables: 5
+      sticky_table_place_ball_fall_prob: 1.00
+      active_sampler_learning_explore_length_base: 25
+      active_sampler_learning_exploration_epsilon: 0.5
+      skill_competence_model_optimistic_recency_size: 2
+      skill_competence_model_optimistic_window_size: 2
+      horizon: 8
+      active_sampler_learning_explore_length_base: 100000  # effectively disable
+      active_sampler_learning_feature_selection: oracle
+      max_num_steps_interaction_request: 100
   spot_sweeping_sim:
     NAME: "spot_main_sweep_env"
     FLAGS:
@@ -84,23 +84,23 @@ ENVS:
       segmenter: spot
       active_sampler_learning_explore_pursue_goal_interval: 1
       max_num_steps_interaction_request: 200
-  # spot_sweeping_sim_yogurt_only:
-  #   NAME: "spot_main_sweep_env"
-  #   FLAGS:
-  #     spot_sweep_env_goal_description: "'get the yogurt into the bucket'"
-  #     active_sampler_learning_explore_length_base: 25
-  #     active_sampler_learning_exploration_epsilon: 0.5
-  #     skill_competence_model_optimistic_recency_size: 2
-  #     skill_competence_model_optimistic_window_size: 2
-  #     horizon: 15
-  #     active_sampler_learning_explore_length_base: 100000  # effectively disable
-  #     active_sampler_learning_feature_selection: oracle
-  #     active_sampler_learning_init_cycles_to_pursue_goal: 5
-  #     spot_run_dry: True
-  #     perceiver: spot_perceiver
-  #     approach_wrapper: spot_wrapper
-  #     segmenter: spot
-  #     max_num_steps_interaction_request: 100
+  spot_sweeping_sim_yogurt_only:
+    NAME: "spot_main_sweep_env"
+    FLAGS:
+      spot_sweep_env_goal_description: "'get the yogurt into the bucket'"
+      active_sampler_learning_explore_length_base: 25
+      active_sampler_learning_exploration_epsilon: 0.5
+      skill_competence_model_optimistic_recency_size: 2
+      skill_competence_model_optimistic_window_size: 2
+      horizon: 15
+      active_sampler_learning_explore_length_base: 100000  # effectively disable
+      active_sampler_learning_feature_selection: oracle
+      active_sampler_learning_init_cycles_to_pursue_goal: 5
+      spot_run_dry: True
+      perceiver: spot_perceiver
+      approach_wrapper: spot_wrapper
+      segmenter: spot
+      max_num_steps_interaction_request: 100
 ARGS: []
 FLAGS:
   num_test_tasks: 10

--- a/scripts/configs/active_sampler_learning.yaml
+++ b/scripts/configs/active_sampler_learning.yaml
@@ -16,13 +16,18 @@ APPROACHES:
     FLAGS:
       explorer: "active_sampler"
       active_sampler_explore_task_strategy: "success_rate"
-      active_sampler_explore_use_ucb_bonus: False
-  success_rate_explore_no_ucb:
+      active_sampler_explore_use_ucb_bonus: True
+  competence_gradient_explore_ucb:
     NAME: "active_sampler_learning"
     FLAGS:
       explorer: "active_sampler"
-      active_sampler_explore_task_strategy: "success_rate"
-      active_sampler_explore_use_ucb_bonus: False
+      active_sampler_explore_task_strategy: "competence_gradient"
+      active_sampler_explore_use_ucb_bonus: True
+  skill_diversity_explore_ucb:
+    NAME: "active_sampler_learning"
+    FLAGS:
+      explorer: "active_sampler"
+      active_sampler_explore_task_strategy: "skill_diversity"
   random_score_explore:
     NAME: "active_sampler_learning"
     FLAGS:

--- a/scripts/configs/active_sampler_learning.yaml
+++ b/scripts/configs/active_sampler_learning.yaml
@@ -37,9 +37,6 @@ APPROACHES:
   #   NAME: "active_sampler_learning"
   #   FLAGS:
   #     explorer: "random_nsrts"
-  # NOTE: maple_q has to be run separately for the spot
-  # environments because one of the flags needs to be
-  # commented out.
   maple_q:
     NAME: "maple_q"
     FLAGS:
@@ -83,9 +80,6 @@ ENVS:
       active_sampler_learning_feature_selection: oracle
       spot_run_dry: True
       perceiver: spot_perceiver
-      # IMPORTANT: Comment out the below line when running the
-      # MAPLE-Q experiments
-      # approach_wrapper: spot_wrapper
       segmenter: spot
       active_sampler_learning_explore_pursue_goal_interval: 1
       max_num_steps_interaction_request: 200

--- a/scripts/configs/active_sampler_learning.yaml
+++ b/scripts/configs/active_sampler_learning.yaml
@@ -1,42 +1,45 @@
 # Final active sampler learning experiments.
 ---
 APPROACHES:
-  planning_progress_explore:
-    NAME: "active_sampler_learning"
-    FLAGS:
-      explorer: "active_sampler"
-      active_sampler_explore_task_strategy: "planning_progress"
-  task_repeat_explore:
-    NAME: "active_sampler_learning"
-    FLAGS:
-      explorer: "active_sampler"
-      active_sampler_explore_task_strategy: "task_repeat"
-  success_rate_explore_ucb:
-    NAME: "active_sampler_learning"
-    FLAGS:
-      explorer: "active_sampler"
-      active_sampler_explore_task_strategy: "success_rate"
-      active_sampler_explore_use_ucb_bonus: True
-  competence_gradient_explore_ucb:
-    NAME: "active_sampler_learning"
-    FLAGS:
-      explorer: "active_sampler"
-      active_sampler_explore_task_strategy: "competence_gradient"
-      active_sampler_explore_use_ucb_bonus: True
-  skill_diversity_explore_ucb:
-    NAME: "active_sampler_learning"
-    FLAGS:
-      explorer: "active_sampler"
-      active_sampler_explore_task_strategy: "skill_diversity"
-  random_score_explore:
-    NAME: "active_sampler_learning"
-    FLAGS:
-      explorer: "active_sampler"
-      active_sampler_explore_task_strategy: "random"
-  random_nsrts_explore:
-    NAME: "active_sampler_learning"
-    FLAGS:
-      explorer: "random_nsrts"
+  # planning_progress_explore:
+  #   NAME: "active_sampler_learning"
+  #   FLAGS:
+  #     explorer: "active_sampler"
+  #     active_sampler_explore_task_strategy: "planning_progress"
+  # task_repeat_explore:
+  #   NAME: "active_sampler_learning"
+  #   FLAGS:
+  #     explorer: "active_sampler"
+  #     active_sampler_explore_task_strategy: "task_repeat"
+  # success_rate_explore_ucb:
+  #   NAME: "active_sampler_learning"
+  #   FLAGS:
+  #     explorer: "active_sampler"
+  #     active_sampler_explore_task_strategy: "success_rate"
+  #     active_sampler_explore_use_ucb_bonus: True
+  # competence_gradient_explore_ucb:
+  #   NAME: "active_sampler_learning"
+  #   FLAGS:
+  #     explorer: "active_sampler"
+  #     active_sampler_explore_task_strategy: "competence_gradient"
+  #     active_sampler_explore_use_ucb_bonus: True
+  # skill_diversity_explore_ucb:
+  #   NAME: "active_sampler_learning"
+  #   FLAGS:
+  #     explorer: "active_sampler"
+  #     active_sampler_explore_task_strategy: "skill_diversity"
+  # random_score_explore:
+  #   NAME: "active_sampler_learning"
+  #   FLAGS:
+  #     explorer: "active_sampler"
+  #     active_sampler_explore_task_strategy: "random"
+  # random_nsrts_explore:
+  #   NAME: "active_sampler_learning"
+  #   FLAGS:
+  #     explorer: "random_nsrts"
+  # NOTE: maple_q has to be run separately for the spot
+  # environments because one of the flags needs to be
+  # commented out.
   maple_q:
     NAME: "maple_q"
     FLAGS:
@@ -44,30 +47,30 @@ APPROACHES:
       mlp_regressor_max_itr: 100000
       active_sampler_learning_batch_size: 1024
 ENVS:
-  grid_row:
-    NAME: "grid_row"
-    FLAGS:
-      active_sampler_learning_explore_length_base: 100000  # effectively disable
-      active_sampler_learning_feature_selection: all
-      active_sampler_learning_explore_pursue_goal_interval: 1
-      max_num_steps_interaction_request: 150
-  ball_and_cup_sticky_table:
-    NAME: "ball_and_cup_sticky_table"
-    FLAGS:
-      sticky_table_place_smooth_fall_prob: 1.00
-      sticky_table_place_sticky_fall_prob: 0.00
-      sticky_table_pick_success_prob: 1.0
-      sticky_table_num_sticky_tables: 1
-      sticky_table_num_tables: 5
-      sticky_table_place_ball_fall_prob: 1.00
-      active_sampler_learning_explore_length_base: 25
-      active_sampler_learning_exploration_epsilon: 0.5
-      skill_competence_model_optimistic_recency_size: 2
-      skill_competence_model_optimistic_window_size: 2
-      horizon: 8
-      active_sampler_learning_explore_length_base: 100000  # effectively disable
-      active_sampler_learning_feature_selection: oracle
-      max_num_steps_interaction_request: 100
+  # grid_row:
+  #   NAME: "grid_row"
+  #   FLAGS:
+  #     active_sampler_learning_explore_length_base: 100000  # effectively disable
+  #     active_sampler_learning_feature_selection: all
+  #     active_sampler_learning_explore_pursue_goal_interval: 1
+  #     max_num_steps_interaction_request: 150
+  # ball_and_cup_sticky_table:
+  #   NAME: "ball_and_cup_sticky_table"
+  #   FLAGS:
+  #     sticky_table_place_smooth_fall_prob: 1.00
+  #     sticky_table_place_sticky_fall_prob: 0.00
+  #     sticky_table_pick_success_prob: 1.0
+  #     sticky_table_num_sticky_tables: 1
+  #     sticky_table_num_tables: 5
+  #     sticky_table_place_ball_fall_prob: 1.00
+  #     active_sampler_learning_explore_length_base: 25
+  #     active_sampler_learning_exploration_epsilon: 0.5
+  #     skill_competence_model_optimistic_recency_size: 2
+  #     skill_competence_model_optimistic_window_size: 2
+  #     horizon: 8
+  #     active_sampler_learning_explore_length_base: 100000  # effectively disable
+  #     active_sampler_learning_feature_selection: oracle
+  #     max_num_steps_interaction_request: 100
   spot_sweeping_sim:
     NAME: "spot_main_sweep_env"
     FLAGS:
@@ -80,27 +83,31 @@ ENVS:
       active_sampler_learning_feature_selection: oracle
       spot_run_dry: True
       perceiver: spot_perceiver
-      approach_wrapper: spot_wrapper
+      # IMPORTANT: Comment out the below line when running the
+      # MAPLE-Q experiments
+      # approach_wrapper: spot_wrapper
       segmenter: spot
       active_sampler_learning_explore_pursue_goal_interval: 1
       max_num_steps_interaction_request: 200
-  spot_sweeping_sim_yogurt_only:
-    NAME: "spot_main_sweep_env"
-    FLAGS:
-      spot_sweep_env_goal_description: "'get the yogurt into the bucket'"
-      active_sampler_learning_explore_length_base: 25
-      active_sampler_learning_exploration_epsilon: 0.5
-      skill_competence_model_optimistic_recency_size: 2
-      skill_competence_model_optimistic_window_size: 2
-      horizon: 15
-      active_sampler_learning_explore_length_base: 100000  # effectively disable
-      active_sampler_learning_feature_selection: oracle
-      active_sampler_learning_init_cycles_to_pursue_goal: 5
-      spot_run_dry: True
-      perceiver: spot_perceiver
-      approach_wrapper: spot_wrapper
-      segmenter: spot
-      max_num_steps_interaction_request: 100
+  # spot_sweeping_sim_yogurt_only:
+  #   NAME: "spot_main_sweep_env"
+  #   FLAGS:
+  #     spot_sweep_env_goal_description: "'get the yogurt into the bucket'"
+  #     active_sampler_learning_explore_length_base: 25
+  #     active_sampler_learning_exploration_epsilon: 0.5
+  #     skill_competence_model_optimistic_recency_size: 2
+  #     skill_competence_model_optimistic_window_size: 2
+  #     horizon: 15
+  #     active_sampler_learning_explore_length_base: 100000  # effectively disable
+  #     active_sampler_learning_feature_selection: oracle
+  #     active_sampler_learning_init_cycles_to_pursue_goal: 5
+  #     spot_run_dry: True
+  #     perceiver: spot_perceiver
+  #     # IMPORTANT: Comment out the below line when running the
+  #     # MAPLE-Q experiments
+  #     approach_wrapper: spot_wrapper
+  #     segmenter: spot
+  #     max_num_steps_interaction_request: 100
 ARGS: []
 FLAGS:
   num_test_tasks: 10

--- a/scripts/configs/active_sampler_learning.yaml
+++ b/scripts/configs/active_sampler_learning.yaml
@@ -76,6 +76,7 @@ ENVS:
       perceiver: spot_perceiver
       approach_wrapper: spot_wrapper
       segmenter: spot
+      active_sampler_learning_explore_pursue_goal_interval: 1
 ARGS: []
 FLAGS:
   num_test_tasks: 10

--- a/scripts/configs/active_sampler_learning.yaml
+++ b/scripts/configs/active_sampler_learning.yaml
@@ -6,38 +6,38 @@ APPROACHES:
     FLAGS:
       explorer: "active_sampler"
       active_sampler_explore_task_strategy: "planning_progress"
-  # task_repeat_explore:
-  #   NAME: "active_sampler_learning"
-  #   FLAGS:
-  #     explorer: "active_sampler"
-  #     active_sampler_explore_task_strategy: "task_repeat"
-  # success_rate_explore_ucb:
-  #   NAME: "active_sampler_learning"
-  #   FLAGS:
-  #     explorer: "active_sampler"
-  #     active_sampler_explore_task_strategy: "success_rate"
-  #     active_sampler_explore_use_ucb_bonus: False
-  # success_rate_explore_no_ucb:
-  #   NAME: "active_sampler_learning"
-  #   FLAGS:
-  #     explorer: "active_sampler"
-  #     active_sampler_explore_task_strategy: "success_rate"
-  #     active_sampler_explore_use_ucb_bonus: False
-  # random_score_explore:
-  #   NAME: "active_sampler_learning"
-  #   FLAGS:
-  #     explorer: "active_sampler"
-  #     active_sampler_explore_task_strategy: "random"
-  # random_nsrts_explore:
-  #   NAME: "active_sampler_learning"
-  #   FLAGS:
-  #     explorer: "random_nsrts"
-  # maple_q:
-  #   NAME: "maple_q"
-  #   FLAGS:
-  #     explorer: "maple_q"
-  #     mlp_regressor_max_itr: 100000
-  #     active_sampler_learning_batch_size: 1024
+  task_repeat_explore:
+    NAME: "active_sampler_learning"
+    FLAGS:
+      explorer: "active_sampler"
+      active_sampler_explore_task_strategy: "task_repeat"
+  success_rate_explore_ucb:
+    NAME: "active_sampler_learning"
+    FLAGS:
+      explorer: "active_sampler"
+      active_sampler_explore_task_strategy: "success_rate"
+      active_sampler_explore_use_ucb_bonus: False
+  success_rate_explore_no_ucb:
+    NAME: "active_sampler_learning"
+    FLAGS:
+      explorer: "active_sampler"
+      active_sampler_explore_task_strategy: "success_rate"
+      active_sampler_explore_use_ucb_bonus: False
+  random_score_explore:
+    NAME: "active_sampler_learning"
+    FLAGS:
+      explorer: "active_sampler"
+      active_sampler_explore_task_strategy: "random"
+  random_nsrts_explore:
+    NAME: "active_sampler_learning"
+    FLAGS:
+      explorer: "random_nsrts"
+  maple_q:
+    NAME: "maple_q"
+    FLAGS:
+      explorer: "maple_q"
+      mlp_regressor_max_itr: 100000
+      active_sampler_learning_batch_size: 1024
 ENVS:
   # grid_row:
   #   NAME: "grid_row"
@@ -77,6 +77,7 @@ ENVS:
       approach_wrapper: spot_wrapper
       segmenter: spot
       active_sampler_learning_explore_pursue_goal_interval: 1
+      max_num_steps_interaction_request: 200
 ARGS: []
 FLAGS:
   num_test_tasks: 10
@@ -91,11 +92,11 @@ FLAGS:
   active_sampler_learning_model: "myopic_classifier_mlp"
   active_sampler_learning_use_teacher: False
   online_nsrt_learning_requests_per_cycle: 1
-  max_num_steps_interaction_request: 100
+  # max_num_steps_interaction_request: 100
   num_online_learning_cycles: 10
   sesame_task_planner: "fdopt-costs"
   sesame_grounder: "fd_translator"
   active_sampler_learning_n_iter_no_change: 5000
   spot_graph_nav_map: "floor8-sweeping"
 START_SEED: 456
-NUM_SEEDS: 1
+NUM_SEEDS: 10

--- a/scripts/plotting/create_active_sampler_learning_plots.py
+++ b/scripts/plotting/create_active_sampler_learning_plots.py
@@ -86,14 +86,16 @@ PLOT_GROUPS = {
             lambda v: "grid_row-planning_progress_explore" in v)),
         ("Task Repeat", "orange", lambda df: df["EXPERIMENT_ID"].apply(
             lambda v: "grid_row-task_repeat_explore" in v)),
-        ("Fail Focus Non-UCB", "brown", lambda df: df["EXPERIMENT_ID"].apply(
-            lambda v: "grid_row-success_rate_explore_no_ucb" in v)),
-        ("Fail Focus UCB", "red", lambda df: df["EXPERIMENT_ID"].apply(
+        ("Competence Gradient", "yellow", lambda df: df["EXPERIMENT_ID"].apply(
+            lambda v: "grid_row-competence_gradient" in v)),
+        ("Fail Focus", "red", lambda df: df["EXPERIMENT_ID"].apply(
             lambda v: "grid_row-success_rate_explore_ucb" in v)),
         ("Task-Relevant", "purple", lambda df: df["EXPERIMENT_ID"].apply(
             lambda v: "grid_row-random_score_explore" in v)),
         ("Random Skills", "blue", lambda df: df["EXPERIMENT_ID"].apply(
             lambda v: "grid_row-random_nsrts_explore" in v)),
+        ("Skill Diversity", "pink", lambda df: df["EXPERIMENT_ID"].apply(
+            lambda v: "grid_row-skill_diversity" in v)),
         ("MAPLE-Q", "silver", lambda df: df["EXPERIMENT_ID"].apply(
             lambda v: "grid_row-maple_q" in v)),
     ],
@@ -102,14 +104,16 @@ PLOT_GROUPS = {
             lambda v: "sticky_table-planning_progress_explore" in v)),
         ("Task Repeat", "orange", lambda df: df["EXPERIMENT_ID"].apply(
             lambda v: "sticky_table-task_repeat_explore" in v)),
-        ("Fail Focus Non-UCB", "brown", lambda df: df["EXPERIMENT_ID"].apply(
-            lambda v: "sticky_table-success_rate_explore_no_ucb" in v)),
-        ("Fail Focus UCB", "red", lambda df: df["EXPERIMENT_ID"].apply(
+        ("Competence Gradient", "yellow", lambda df: df["EXPERIMENT_ID"].apply(
+            lambda v: "sticky_table-competence_gradient" in v)),
+        ("Fail Focus", "red", lambda df: df["EXPERIMENT_ID"].apply(
             lambda v: "sticky_table-success_rate_explore_ucb" in v)),
         ("Task-Relevant", "purple", lambda df: df["EXPERIMENT_ID"].apply(
             lambda v: "sticky_table-random_score_explore" in v)),
         ("Random Skills", "blue", lambda df: df["EXPERIMENT_ID"].apply(
             lambda v: "sticky_table-random_nsrts_explore" in v)),
+        ("Skill Diversity", "pink", lambda df: df["EXPERIMENT_ID"].apply(
+            lambda v: "sticky_table-skill_diversity" in v)),
         ("MAPLE-Q", "silver", lambda df: df["EXPERIMENT_ID"].apply(
             lambda v: "sticky_table-maple_q" in v)),
     ],
@@ -118,14 +122,16 @@ PLOT_GROUPS = {
             lambda v: "spot_sweeping_sim-planning_progress_explore" in v)),
         ("Task Repeat", "orange", lambda df: df["EXPERIMENT_ID"].apply(
             lambda v: "spot_sweeping_sim-task_repeat_explore" in v)),
-        ("Fail Focus Non-UCB", "brown", lambda df: df["EXPERIMENT_ID"].apply(
-            lambda v: "spot_sweeping_sim-success_rate_explore_no_ucb" in v)),
-        ("Fail Focus UCB", "red", lambda df: df["EXPERIMENT_ID"].apply(
+        ("Competence Gradient", "yellow", lambda df: df["EXPERIMENT_ID"].apply(
+            lambda v: "spot_sweeping_sim-competence_gradient" in v)),
+        ("Fail Focus", "red", lambda df: df["EXPERIMENT_ID"].apply(
             lambda v: "spot_sweeping_sim-success_rate_explore_ucb" in v)),
         ("Task-Relevant", "purple", lambda df: df["EXPERIMENT_ID"].apply(
-            lambda v: "spot_sweeping_sim-random_score_explore" in v)),
+            lambda v: "spot_sweeping_simrandom_score_explore" in v)),
         ("Random Skills", "blue", lambda df: df["EXPERIMENT_ID"].apply(
             lambda v: "spot_sweeping_sim-random_nsrts_explore" in v)),
+        ("Skill Diversity", "pink", lambda df: df["EXPERIMENT_ID"].apply(
+            lambda v: "spot_sweeping_sim-skill_diversity" in v)),
         ("MAPLE-Q", "silver", lambda df: df["EXPERIMENT_ID"].apply(
             lambda v: "spot_sweeping_sim-maple_q" in v)),
     ],

--- a/scripts/plotting/create_active_sampler_learning_plots.py
+++ b/scripts/plotting/create_active_sampler_learning_plots.py
@@ -81,54 +81,53 @@ Y_KEY_AND_LABEL = [
 # The keys of the outer dict are plot titles.
 # The keys of the inner dict are (legend label, marker, df selector).
 PLOT_GROUPS = {
-    "Regional Bumpy Cover": [
+    # "Grid 1D Environment": [
+    #     ("Planning Progress", "green", lambda df: df["EXPERIMENT_ID"].apply(
+    #         lambda v: "grid_row-planning_progress_explore" in v)),
+    #     ("Task Repeat", "orange", lambda df: df["EXPERIMENT_ID"].apply(
+    #         lambda v: "grid_row-task_repeat_explore" in v)),
+    #     ("Fail Focus Non-UCB", "brown", lambda df: df["EXPERIMENT_ID"].apply(
+    #         lambda v: "grid_row-success_rate_explore_no_ucb" in v)),
+    #     ("Fail Focus UCB", "red", lambda df: df["EXPERIMENT_ID"].apply(
+    #         lambda v: "grid_row-success_rate_explore_ucb" in v)),
+    #     ("Task-Relevant", "purple", lambda df: df["EXPERIMENT_ID"].apply(
+    #         lambda v: "grid_row-random_score_explore" in v)),
+    #     ("Random Skills", "blue", lambda df: df["EXPERIMENT_ID"].apply(
+    #         lambda v: "grid_row-random_nsrts_explore" in v)),
+    #     ("MAPLE-Q", "silver", lambda df: df["EXPERIMENT_ID"].apply(
+    #         lambda v: "grid_row-maple_q" in v)),
+    # ],
+    # "Ball and Cup Sticky Table": [
+    #     ("Planning Progress", "green", lambda df: df["EXPERIMENT_ID"].apply(
+    #         lambda v: "sticky_table-planning_progress_explore" in v)),
+    #     ("Task Repeat", "orange", lambda df: df["EXPERIMENT_ID"].apply(
+    #         lambda v: "sticky_table-task_repeat_explore" in v)),
+    #     ("Fail Focus Non-UCB", "brown", lambda df: df["EXPERIMENT_ID"].apply(
+    #         lambda v: "sticky_table-success_rate_explore_no_ucb" in v)),
+    #     ("Fail Focus UCB", "red", lambda df: df["EXPERIMENT_ID"].apply(
+    #         lambda v: "sticky_table-success_rate_explore_ucb" in v)),
+    #     ("Task-Relevant", "purple", lambda df: df["EXPERIMENT_ID"].apply(
+    #         lambda v: "sticky_table-random_score_explore" in v)),
+    #     ("Random Skills", "blue", lambda df: df["EXPERIMENT_ID"].apply(
+    #         lambda v: "sticky_table-random_nsrts_explore" in v)),
+    #     ("MAPLE-Q", "silver", lambda df: df["EXPERIMENT_ID"].apply(
+    #         lambda v: "sticky_table-maple_q" in v)),
+    # ],
+    "Cleanup Playroom": [
         ("Planning Progress", "green", lambda df: df["EXPERIMENT_ID"].apply(
-            lambda v: "regional_bumpy_cover-planning_progress_explore" in v)),
+            lambda v: "spot_sweeping_sim-planning_progress_explore" in v)),
         ("Task Repeat", "orange", lambda df: df["EXPERIMENT_ID"].apply(
-            lambda v: "regional_bumpy_cover-task_repeat_explore" in v)),
+            lambda v: "spot_sweeping_sim-task_repeat_explore" in v)),
         ("Fail Focus Non-UCB", "brown", lambda df: df["EXPERIMENT_ID"].apply(
-            lambda v: "regional_bumpy_cover-success_rate_explore_no_ucb" in v)
-         ),
+            lambda v: "spot_sweeping_sim-success_rate_explore_no_ucb" in v)),
         ("Fail Focus UCB", "red", lambda df: df["EXPERIMENT_ID"].apply(
-            lambda v: "regional_bumpy_cover-success_rate_explore_ucb" in v)),
+            lambda v: "spot_sweeping_sim-success_rate_explore_ucb" in v)),
         ("Task-Relevant", "purple", lambda df: df["EXPERIMENT_ID"].apply(
-            lambda v: "regional_bumpy_cover-random_score_explore" in v)),
+            lambda v: "spot_sweeping_sim-random_score_explore" in v)),
         ("Random Skills", "blue", lambda df: df["EXPERIMENT_ID"].apply(
-            lambda v: "regional_bumpy_cover-random_nsrts_explore" in v)),
+            lambda v: "spot_sweeping_sim-random_nsrts_explore" in v)),
         ("MAPLE-Q", "silver", lambda df: df["EXPERIMENT_ID"].apply(
-            lambda v: "regional_bumpy_cover-maple_q" in v)),
-    ],
-    "Grid 1D Environment": [
-        ("Planning Progress", "green", lambda df: df["EXPERIMENT_ID"].apply(
-            lambda v: "grid_row-planning_progress_explore" in v)),
-        ("Task Repeat", "orange", lambda df: df["EXPERIMENT_ID"].apply(
-            lambda v: "grid_row-task_repeat_explore" in v)),
-        ("Fail Focus Non-UCB", "brown", lambda df: df["EXPERIMENT_ID"].apply(
-            lambda v: "grid_row-success_rate_explore_no_ucb" in v)),
-        ("Fail Focus UCB", "red", lambda df: df["EXPERIMENT_ID"].apply(
-            lambda v: "grid_row-success_rate_explore_ucb" in v)),
-        ("Task-Relevant", "purple", lambda df: df["EXPERIMENT_ID"].apply(
-            lambda v: "grid_row-random_score_explore" in v)),
-        ("Random Skills", "blue", lambda df: df["EXPERIMENT_ID"].apply(
-            lambda v: "grid_row-random_nsrts_explore" in v)),
-        ("MAPLE-Q", "silver", lambda df: df["EXPERIMENT_ID"].apply(
-            lambda v: "grid_row-maple_q" in v)),
-    ],
-    "Ball and Cup Sticky Table": [
-        ("Planning Progress", "green", lambda df: df["EXPERIMENT_ID"].apply(
-            lambda v: "sticky_table-planning_progress_explore" in v)),
-        ("Task Repeat", "orange", lambda df: df["EXPERIMENT_ID"].apply(
-            lambda v: "sticky_table-task_repeat_explore" in v)),
-        ("Fail Focus Non-UCB", "brown", lambda df: df["EXPERIMENT_ID"].apply(
-            lambda v: "sticky_table-success_rate_explore_no_ucb" in v)),
-        ("Fail Focus UCB", "red", lambda df: df["EXPERIMENT_ID"].apply(
-            lambda v: "sticky_table-success_rate_explore_ucb" in v)),
-        ("Task-Relevant", "purple", lambda df: df["EXPERIMENT_ID"].apply(
-            lambda v: "sticky_table-random_score_explore" in v)),
-        ("Random Skills", "blue", lambda df: df["EXPERIMENT_ID"].apply(
-            lambda v: "sticky_table-random_nsrts_explore" in v)),
-        ("MAPLE-Q", "silver", lambda df: df["EXPERIMENT_ID"].apply(
-            lambda v: "sticky_table-maple_q" in v)),
+            lambda v: "spot_sweeping_sim-maple_q" in v)),
     ],
 }
 

--- a/scripts/plotting/create_active_sampler_learning_plots.py
+++ b/scripts/plotting/create_active_sampler_learning_plots.py
@@ -81,38 +81,38 @@ Y_KEY_AND_LABEL = [
 # The keys of the outer dict are plot titles.
 # The keys of the inner dict are (legend label, marker, df selector).
 PLOT_GROUPS = {
-    # "Grid 1D Environment": [
-    #     ("Planning Progress", "green", lambda df: df["EXPERIMENT_ID"].apply(
-    #         lambda v: "grid_row-planning_progress_explore" in v)),
-    #     ("Task Repeat", "orange", lambda df: df["EXPERIMENT_ID"].apply(
-    #         lambda v: "grid_row-task_repeat_explore" in v)),
-    #     ("Fail Focus Non-UCB", "brown", lambda df: df["EXPERIMENT_ID"].apply(
-    #         lambda v: "grid_row-success_rate_explore_no_ucb" in v)),
-    #     ("Fail Focus UCB", "red", lambda df: df["EXPERIMENT_ID"].apply(
-    #         lambda v: "grid_row-success_rate_explore_ucb" in v)),
-    #     ("Task-Relevant", "purple", lambda df: df["EXPERIMENT_ID"].apply(
-    #         lambda v: "grid_row-random_score_explore" in v)),
-    #     ("Random Skills", "blue", lambda df: df["EXPERIMENT_ID"].apply(
-    #         lambda v: "grid_row-random_nsrts_explore" in v)),
-    #     ("MAPLE-Q", "silver", lambda df: df["EXPERIMENT_ID"].apply(
-    #         lambda v: "grid_row-maple_q" in v)),
-    # ],
-    # "Ball and Cup Sticky Table": [
-    #     ("Planning Progress", "green", lambda df: df["EXPERIMENT_ID"].apply(
-    #         lambda v: "sticky_table-planning_progress_explore" in v)),
-    #     ("Task Repeat", "orange", lambda df: df["EXPERIMENT_ID"].apply(
-    #         lambda v: "sticky_table-task_repeat_explore" in v)),
-    #     ("Fail Focus Non-UCB", "brown", lambda df: df["EXPERIMENT_ID"].apply(
-    #         lambda v: "sticky_table-success_rate_explore_no_ucb" in v)),
-    #     ("Fail Focus UCB", "red", lambda df: df["EXPERIMENT_ID"].apply(
-    #         lambda v: "sticky_table-success_rate_explore_ucb" in v)),
-    #     ("Task-Relevant", "purple", lambda df: df["EXPERIMENT_ID"].apply(
-    #         lambda v: "sticky_table-random_score_explore" in v)),
-    #     ("Random Skills", "blue", lambda df: df["EXPERIMENT_ID"].apply(
-    #         lambda v: "sticky_table-random_nsrts_explore" in v)),
-    #     ("MAPLE-Q", "silver", lambda df: df["EXPERIMENT_ID"].apply(
-    #         lambda v: "sticky_table-maple_q" in v)),
-    # ],
+    "Grid 1D Environment": [
+        ("Planning Progress", "green", lambda df: df["EXPERIMENT_ID"].apply(
+            lambda v: "grid_row-planning_progress_explore" in v)),
+        ("Task Repeat", "orange", lambda df: df["EXPERIMENT_ID"].apply(
+            lambda v: "grid_row-task_repeat_explore" in v)),
+        ("Fail Focus Non-UCB", "brown", lambda df: df["EXPERIMENT_ID"].apply(
+            lambda v: "grid_row-success_rate_explore_no_ucb" in v)),
+        ("Fail Focus UCB", "red", lambda df: df["EXPERIMENT_ID"].apply(
+            lambda v: "grid_row-success_rate_explore_ucb" in v)),
+        ("Task-Relevant", "purple", lambda df: df["EXPERIMENT_ID"].apply(
+            lambda v: "grid_row-random_score_explore" in v)),
+        ("Random Skills", "blue", lambda df: df["EXPERIMENT_ID"].apply(
+            lambda v: "grid_row-random_nsrts_explore" in v)),
+        ("MAPLE-Q", "silver", lambda df: df["EXPERIMENT_ID"].apply(
+            lambda v: "grid_row-maple_q" in v)),
+    ],
+    "Ball and Cup Sticky Table": [
+        ("Planning Progress", "green", lambda df: df["EXPERIMENT_ID"].apply(
+            lambda v: "sticky_table-planning_progress_explore" in v)),
+        ("Task Repeat", "orange", lambda df: df["EXPERIMENT_ID"].apply(
+            lambda v: "sticky_table-task_repeat_explore" in v)),
+        ("Fail Focus Non-UCB", "brown", lambda df: df["EXPERIMENT_ID"].apply(
+            lambda v: "sticky_table-success_rate_explore_no_ucb" in v)),
+        ("Fail Focus UCB", "red", lambda df: df["EXPERIMENT_ID"].apply(
+            lambda v: "sticky_table-success_rate_explore_ucb" in v)),
+        ("Task-Relevant", "purple", lambda df: df["EXPERIMENT_ID"].apply(
+            lambda v: "sticky_table-random_score_explore" in v)),
+        ("Random Skills", "blue", lambda df: df["EXPERIMENT_ID"].apply(
+            lambda v: "sticky_table-random_nsrts_explore" in v)),
+        ("MAPLE-Q", "silver", lambda df: df["EXPERIMENT_ID"].apply(
+            lambda v: "sticky_table-maple_q" in v)),
+    ],
     "Cleanup Playroom": [
         ("Planning Progress", "green", lambda df: df["EXPERIMENT_ID"].apply(
             lambda v: "spot_sweeping_sim-planning_progress_explore" in v)),


### PR DESCRIPTION
Notable changes:
- Adds a `IsSemanticallyGreaterThan` predicate to enforce canonicity in grounding of operators like `SweepTwoObjectsIntoContainer`
- MAPLE-Q was broken in this env because of the fact that all our training tasks are 'dummy'. This should now handle that case.