### PR TITLE
updates to active sampler learning script

### DIFF
--- a/predicators/spot_utils/graph_nav_maps/floor8-sweeping/metadata.yaml
+++ b/predicators/spot_utils/graph_nav_maps/floor8-sweeping/metadata.yaml
@@ -12,8 +12,8 @@ april-tag-offsets: []
 # points.
 allowed-regions:
   main-room:
-    - [0.5, -2.25]
-    - [0.5, 1.0]
+    - [0.25, -2.25]
+    - [0.25, 1.0]
     - [4.0, 1.0]
     - [4.0, -2.25]
 # Known immovable objects. Assuming default rotations.

--- a/scripts/configs/spot_active_sampler_learning.yaml
+++ b/scripts/configs/spot_active_sampler_learning.yaml
@@ -7,17 +7,26 @@ APPROACHES:
       explorer: "active_sampler"
       active_sampler_explore_task_strategy: "planning_progress"
 ENVS:
-  spot_ball_and_cup_sticky_table_env:
-    NAME: "spot_ball_and_cup_sticky_table_env"
+  # spot_ball_and_cup_sticky_table_env:
+  #   NAME: "spot_ball_and_cup_sticky_table_env"
+  #   FLAGS:
+  #     spot_robot_ip: "10.17.30.21"  # Donner
+  #     perceiver: "spot_perceiver"
+  #     execution_monitor: "expected_atoms"
+  #     spot_graph_nav_map: "floor8-cup-table"
+  #     spot_render_perception_outputs: False
+  #     active_sampler_learning_object_specific_samplers: True
+  spot_main_sweep_env:
+    NAME: "spot_main_sweep_env"
     FLAGS:
-      spot_robot_ip: "10.17.30.21"  # Donner
+      spot_robot_ip: 10.17.30.21  # change to "10.0.1.3" for ethernet
       perceiver: "spot_perceiver"
       execution_monitor: "expected_atoms"
-      spot_graph_nav_map: "floor8-cup-table"
-      spot_render_perception_outputs: False
+      spot_graph_nav_map: "floor8-sweeping"
+      spot_render_perception_outputs: False  # change to True for dev
       active_sampler_learning_object_specific_samplers: True
 ARGS:
-  - "debug"
+  - "debug" # add make_cogman_videos for dev
 FLAGS:
   strips_learner: "oracle"
   sampler_learner: "oracle"


### PR DESCRIPTION
here's the DEVELOPMENT command, for convenience:

```
python predicators/main.py --env spot_main_sweep_env --approach spot_wrapper[active_sampler_learning] --experiment_id spot_main_sweep_env-main --debug --strips_learner oracle --sampler_learner oracle --segmenter spot --bilevel_plan_without_sim True --max_initial_demos 0 --num_train_tasks 1000 --num_test_tasks 0 --sampler_mlp_classifier_max_itr 100000 --mlp_classifier_balance_data False --pytorch_train_print_every 10000 --active_sampler_learning_n_iter_no_change 5000 --active_sampler_learning_model myopic_classifier_mlp --active_sampler_learning_use_teacher False --active_sampler_learning_explore_length_base 10000 --active_sampler_learning_exploration_epsilon 0.5 --active_sampler_learning_explore_pursue_goal_interval 3 --active_sampler_learning_init_cycles_to_pursue_goal 5 --skill_competence_model_optimistic_recency_size 5 --skill_competence_model_optimistic_window_size 5 --horizon 15 --active_sampler_learning_feature_selection oracle --online_nsrt_learning_requests_per_cycle 1 --max_num_steps_interaction_request 20 --num_online_learning_cycles 100 --sesame_task_planner fdopt-costs --sesame_grounder fd_translator --explorer active_sampler --active_sampler_explore_task_strategy planning_progress --spot_robot_ip 10.0.1.3 --perceiver spot_perceiver --execution_monitor expected_atoms --spot_graph_nav_map floor8-sweeping --spot_render_perception_outputs True --active_sampler_learning_object_specific_samplers True --seed 123 --make_cogman_videos
```