### PR TITLE
Enabling real-world replanning demo with VLM predicates

### DIFF
--- a/predicators/envs/spot_env.py
+++ b/predicators/envs/spot_env.py
@@ -2677,7 +2677,8 @@ class SpotMinimalVLMPredicateEnv(SpotRearrangementEnv):
             'right_fisheye_image'
         ]
         for camera_name in camera_names:
-            assert camera_name in rgbd_images, f"Missing image from {camera_name}"
+            assert camera_name in rgbd_images, \
+                f"Missing image from {camera_name}"
 
         gripper_open_percentage = get_robot_gripper_open_percentage(
             self._robot)

--- a/predicators/envs/spot_env.py
+++ b/predicators/envs/spot_env.py
@@ -2723,8 +2723,8 @@ class SimpleVLMCupEnv(SpotMinimalVLMPredicateEnv):
             LiftedAtom(_NotHolding, [robot, obj]),
         }
         ignore_effs: Set[Predicate] = set()
-        yield STRIPSOperator("PickObjectFromTop", parameters, preconds,
-                             add_effs, del_effs, ignore_effs)
+        yield STRIPSOperator("TeleopPick1", parameters, preconds, add_effs,
+                             del_effs, ignore_effs)
 
         # Place object
         robot = Variable("?robot", _robot_type)
@@ -2739,8 +2739,8 @@ class SimpleVLMCupEnv(SpotMinimalVLMPredicateEnv):
         }
         del_effs = {LiftedAtom(_Holding, [robot, obj])}
         ignore_effs = set()
-        yield STRIPSOperator("PlaceObjectOnTop", parameters, preconds,
-                             add_effs, del_effs, ignore_effs)
+        yield STRIPSOperator("TeleopPlace1", parameters, preconds, add_effs,
+                             del_effs, ignore_effs)
 
     def op_names_to_keep(self) -> Set[str]:
         """Return the names of the operators we want to keep."""

--- a/predicators/envs/spot_env.py
+++ b/predicators/envs/spot_env.py
@@ -1482,7 +1482,7 @@ def _get_vlm_query_str(pred_name: str, objects: Sequence[Object]) -> str:
 
 _VLMOn = utils.create_vlm_predicate("VLMOn",
                                     [_movable_object_type, _base_object_type],
-                                    lambda o: _get_vlm_query_str("VLMOn", o))
+                                    lambda o: _get_vlm_query_str("OnTopOf", o))
 _Upright = utils.create_vlm_predicate(
     "Upright", [_movable_object_type],
     lambda o: _get_vlm_query_str("Upright", o))
@@ -2641,9 +2641,14 @@ class SpotMinimalVLMPredicateEnv(SpotRearrangementEnv):
                 if response == "y":
                     self._current_task_goal_reached = True
                     break
-                if response == "n":
-                    self._current_task_goal_reached = False
-                    break
+                # If the answer is no, just stay in an infinite loop;
+                # nothing is going to change anyways unless the robot's
+                # state changes.
+                # NOTE: this is a bit of a hack; we should probably
+                # have a better way to handle this later.
+                # if response == "n":
+                #     self._current_task_goal_reached = False
+                #     break
                 logging.info("Invalid input, must be either 'y' or 'n'")
             return _TruncatedSpotObservation(
                 self._current_observation.rgbd_images,
@@ -2665,6 +2670,15 @@ class SpotMinimalVLMPredicateEnv(SpotRearrangementEnv):
                 logging.warning("WARNING: the following retryable error "
                                 f"was encountered. Trying again.\n{e}")
         rgbd_images = capture_images_without_context(self._robot)
+
+        camera_names = [
+            'frontleft_fisheye_image', 'frontright_fisheye_image',
+            'hand_color_image', 'back_fisheye_image', 'left_fisheye_image',
+            'right_fisheye_image'
+        ]
+        for camera_name in camera_names:
+            assert camera_name in rgbd_images, f"Missing image from {camera_name}"
+
         gripper_open_percentage = get_robot_gripper_open_percentage(
             self._robot)
         # Perform object detection.
@@ -2699,7 +2713,7 @@ class SimpleVLMCupEnv(SpotMinimalVLMPredicateEnv):
 
         detection_id_to_obj: Dict[ObjectDetectionID, Object] = {}
         objects = {
-            Object("cup", _movable_object_type),
+            Object("yellow_toy_cup", _movable_object_type),
             Object("cardboard_table", _immovable_object_type),
         }
         for o in objects:
@@ -2711,8 +2725,7 @@ class SimpleVLMCupEnv(SpotMinimalVLMPredicateEnv):
         # Pick object
         robot = Variable("?robot", _robot_type)
         obj = Variable("?object", _movable_object_type)
-        table = Variable("?table", _movable_object_type)
-        parameters = [robot, obj, table]
+        parameters = [robot, obj]
         preconds: Set[LiftedAtom] = {
             LiftedAtom(_HandEmpty, [robot]),
             LiftedAtom(_NotHolding, [robot, obj]),
@@ -2744,7 +2757,7 @@ class SimpleVLMCupEnv(SpotMinimalVLMPredicateEnv):
 
     def op_names_to_keep(self) -> Set[str]:
         """Return the names of the operators we want to keep."""
-        return {"PickObjectFromTop", "PlaceObjectOnTop"}
+        return {"TeleopPick1", "TeleopPlace1"}
 
     def _generate_goal_description(self) -> GoalDescription:
         return "get the cup onto the table!"

--- a/predicators/execution_monitoring/expected_atoms_monitor.py
+++ b/predicators/execution_monitoring/expected_atoms_monitor.py
@@ -42,8 +42,9 @@ class ExpectedAtomsExecutionMonitor(BaseExecutionMonitor):
         }
         vlm_unsat_atoms = set()
         if len(next_expected_vlm_atoms) > 0:
-            vlm_unsat_atoms = utils.query_vlm_for_atom_vals(
-                next_expected_vlm_atoms, state)  # pragma: no cover
+            vlm_unsat_atoms = next_expected_atoms - (
+                utils.query_vlm_for_atom_vals(next_expected_vlm_atoms,
+                                              state))  # pragma: no cover
         unsat_atoms = non_vlm_unsat_atoms | vlm_unsat_atoms
         if not unsat_atoms:
             return False

--- a/predicators/ground_truth_models/spot_env/nsrts.py
+++ b/predicators/ground_truth_models/spot_env/nsrts.py
@@ -322,6 +322,7 @@ class SpotEnvsGroundTruthNSRTFactory(GroundTruthNSRTFactory):
             "DropNotPlaceableObject": utils.null_sampler,
             "MoveToReadySweep": utils.null_sampler,
             "TeleopPick1": utils.null_sampler,
+            "TeleopPlace": utils.null_sampler,
             "PlaceNextTo": utils.null_sampler,
             "TeleopPick2": utils.null_sampler,
             "Sweep": utils.null_sampler,

--- a/predicators/ground_truth_models/spot_env/nsrts.py
+++ b/predicators/ground_truth_models/spot_env/nsrts.py
@@ -322,7 +322,7 @@ class SpotEnvsGroundTruthNSRTFactory(GroundTruthNSRTFactory):
             "DropNotPlaceableObject": utils.null_sampler,
             "MoveToReadySweep": utils.null_sampler,
             "TeleopPick1": utils.null_sampler,
-            "TeleopPlace": utils.null_sampler,
+            "TeleopPlace1": utils.null_sampler,
             "PlaceNextTo": utils.null_sampler,
             "TeleopPick2": utils.null_sampler,
             "Sweep": utils.null_sampler,

--- a/predicators/ground_truth_models/spot_env/options.py
+++ b/predicators/ground_truth_models/spot_env/options.py
@@ -993,6 +993,7 @@ _OPERATOR_NAME_TO_POLICY = {
     "MoveToReadySweep": _move_to_ready_sweep_policy,
     "TeleopPick1": _create_teleop_policy_with_name("TeleopPick1"),
     "PlaceNextTo": _create_teleop_policy_with_name("PlaceNextTo"),
+    "TeleopPlace": _create_teleop_policy_with_name("TeleopPlace"),
     "TeleopPick2": _create_teleop_policy_with_name("TeleopPick2"),
     "Sweep": _create_teleop_policy_with_name("Sweep"),
     "PlaceOnFloor": _create_teleop_policy_with_name("PlaceOnFloor")

--- a/predicators/ground_truth_models/spot_env/options.py
+++ b/predicators/ground_truth_models/spot_env/options.py
@@ -966,6 +966,7 @@ _OPERATOR_NAME_TO_PARAM_SPACE = {
     "TeleopPick1": Box(0, 1, (0, )),  # empty
     "PlaceNextTo": Box(0, 1, (0, )),  # empty
     "TeleopPick2": Box(0, 1, (0, )),  # empty
+    "TeleopPlace1": Box(0, 1, (0, )),  # empty
     "Sweep": Box(0, 1, (0, )),  # empty
     "PlaceOnFloor": Box(0, 1, (0, ))  # empty
 }
@@ -995,6 +996,7 @@ _OPERATOR_NAME_TO_POLICY = {
     "PlaceNextTo": _create_teleop_policy_with_name("PlaceNextTo"),
     "TeleopPlace": _create_teleop_policy_with_name("TeleopPlace"),
     "TeleopPick2": _create_teleop_policy_with_name("TeleopPick2"),
+    "TeleopPlace1": _create_teleop_policy_with_name("TeleopPlace1"),
     "Sweep": _create_teleop_policy_with_name("Sweep"),
     "PlaceOnFloor": _create_teleop_policy_with_name("PlaceOnFloor")
 }

--- a/predicators/perception/spot_perceiver.py
+++ b/predicators/perception/spot_perceiver.py
@@ -640,7 +640,7 @@ class SpotMinimalPerceiver(BasePerceiver):
 
         if goal_description == "get the cup onto the table!":
             robot = Object("robot", _robot_type)
-            cup = Object("cup", _movable_object_type)
+            cup = Object("yellow_toy_cup", _movable_object_type)
             table = Object("cardboard_table", _immovable_object_type)
             goal = {
                 GroundAtom(HandEmpty, [robot]),
@@ -707,6 +707,8 @@ class SpotMinimalPerceiver(BasePerceiver):
             detections = object_detections_per_camera[camera_name]
             for obj_id, seg_bb in detections:
                 x0, y0, x1, y1 = seg_bb.bounding_box
+                x0, x1 = sorted([x0, x1])
+                y0, y1 = sorted([y0, y1])
                 draw.rectangle([(x0, y0), (x1, y1)], outline='green', width=2)
                 text = f"{obj_id.language_id}"
                 font = utils.get_scaled_default_font(draw, 3)
@@ -733,7 +735,7 @@ class SpotMinimalPerceiver(BasePerceiver):
             if "Place" in observation.executed_skill.extra_info.action_name:
                 for obj in observation.executed_skill.extra_info.\
                         operator_objects:
-                    if not obj.is_instance(_robot_type):
+                    if obj.is_instance(_movable_object_type):
                         # Turn the held feature off
                         self._curr_state.set(obj, "held", 0.0)
 

--- a/predicators/perception/spot_perceiver.py
+++ b/predicators/perception/spot_perceiver.py
@@ -721,7 +721,7 @@ class SpotMinimalPerceiver(BasePerceiver):
                           text,
                           fill='white',
                           font=font)
-        annotated_imgs = [img for img in pil_imgs]
+        annotated_imgs = list(pil_imgs)
         self._gripper_open_percentage = observation.gripper_open_percentage
 
         self._curr_state = self._create_state()

--- a/predicators/perception/spot_perceiver.py
+++ b/predicators/perception/spot_perceiver.py
@@ -721,7 +721,7 @@ class SpotMinimalPerceiver(BasePerceiver):
                           text,
                           fill='white',
                           font=font)
-        annotated_imgs = [np.array(img) for img in pil_imgs]
+        annotated_imgs = [img for img in pil_imgs]
         self._gripper_open_percentage = observation.gripper_open_percentage
 
         self._curr_state = self._create_state()

--- a/predicators/planning.py
+++ b/predicators/planning.py
@@ -1204,9 +1204,14 @@ def run_task_plan_once(
         ground_nsrts, reachable_atoms = task_plan_grounding(
             init_atoms, objects, nsrts)
         assert task_planning_heuristic is not None
-        heuristic = utils.create_task_planning_heuristic(
-            task_planning_heuristic, init_atoms, goal, ground_nsrts, preds,
-            objects)
+        try:
+            heuristic = utils.create_task_planning_heuristic(
+                task_planning_heuristic, init_atoms, goal, ground_nsrts, preds,
+                objects)
+        except AssertionError:
+            raise PlanningFailure(
+                "Heuristic creation failed! Common culprit in spot environment is that goal atoms use objects named differently than initial objects"
+            )
         duration = time.perf_counter() - start_time
         timeout -= duration
         plan, atoms_seq, metrics = next(

--- a/predicators/planning.py
+++ b/predicators/planning.py
@@ -1210,7 +1210,9 @@ def run_task_plan_once(
                 objects)
         except AssertionError:
             raise PlanningFailure(
-                "Heuristic creation failed! Common culprit in spot environment is that goal atoms use objects named differently than initial objects"
+                "Heuristic creation failed! Common culprit in spot " +\
+                "environment is that goal atoms use objects named " +\
+                "differently than initial objects"
             )
         duration = time.perf_counter() - start_time
         timeout -= duration

--- a/predicators/planning.py
+++ b/predicators/planning.py
@@ -1208,7 +1208,7 @@ def run_task_plan_once(
             heuristic = utils.create_task_planning_heuristic(
                 task_planning_heuristic, init_atoms, goal, ground_nsrts, preds,
                 objects)
-        except AssertionError:
+        except AssertionError:  # pragma: no cover
             raise PlanningFailure(
                 "Heuristic creation failed! Common culprit in spot " +\
                 "environment is that goal atoms use objects named " +\

--- a/predicators/spot_utils/README.md
+++ b/predicators/spot_utils/README.md
@@ -2,28 +2,35 @@
 
 ## How to run your own Spot environment
 
-> Last Updated: 04/11/2024
+> Last Updated: 02/27/2025
 
 **Steps:**
 - Set up the codebase, perception pipeline, and Spot
   - You need to have access to a GPU server for the perception pipeline (e.g., the Detic-SAM pipeline)
   - You need to connect to Spot (through WiFi or ethernet cable). The Spot at LIS uses its own WiFi AP mode and is on IP `192.168.80.3`.
   - To connect to both Spot and GPU server, our current solution is to use WiFi for Spot and ethernet cable for the GPU server.
-- Create a new map of the environment: See the `Mapping` section.
+- If you want the spot to autonomously execute movement skills, then create a new map of the environment: See the `Mapping` section.
   - Prepare the metadata file: See the `Prepare Metadata` section.
+- Otherwise, you can run a ''minimal'' environment where a human is asked to teleop the skills instead of having spot execute them automatically. This can be helpful for debugging new functionality, etc.
 - Implement your task
 - Start actual run. Examples:
 ```
-# template
-python predicators/main.py --spot_robot_ip <spot_ip> --spot_graph_nav_map <map_name> --env <env_name>
+# template with map (autonomous spot skills)
+python predicators/main.py --spot_robot_ip <spot_ip> --spot_graph_nav_map <map_name> --env <env_name> --approach "spot_wrapper[oracle]"
 
-# an example to run LIS Spot
+# template without map (human teleop skills)
+python predicators/main.py --env <env_name> --approach "spot_wrapper[oracle]" --spot_robot_ip <spot_ip> --perceiver spot_minimal_perceiver 
+
+# an example to run LIS Spot with a room map
 python predicators/main.py --spot_robot_ip 192.168.80.3 --spot_graph_nav_map b45-621 --env lis_spot_block_floor_env --approach spot_wrapper[oracle] --bilevel_plan_without_sim True --seed 0
+
+# an example to run LIS spot without a map
+python predicators/main.py --env spot_vlm_cup_table_env --approach "spot_wrapper[oracle]" --seed 0 --num_train_tasks 0 --num_test_tasks 1 --spot_robot_ip 192.168.80.3 --perceiver spot_minimal_perceiver --bilevel_plan_without_sim True --vlm_test_time_atom_label_prompt_type img_option_diffs_label_history --vlm_model_name gpt-4o --execution_monitor expected_atoms
 ```
 
 ### Implement Your Task
 
-To create a simple task before you can run, you only need to:
+To create a simple task (that uses a map) before you can run, you only need to:
 
 - Create a new environment in `envs/spot_envs.py`
   - In `spot_env.py`, subclass the `SpotRearrangementEnv` and define the necessary methods needed to override.
@@ -34,6 +41,7 @@ To create a simple task before you can run, you only need to:
   - Add environment name into `SpotEnvsGroundTruthOptionFactory` in `ground_truth_models/spot_env/options.py`
 - If you want, define a new `goal_description` string. Then, go to the _`create_goal` function of `spot_perceiver.py` and follow the example to convert a goal description string into an actual set of atoms needed to implement the goal.
 
+To create a new task without using a map (and using human teleop skills), take a look at the `SimpleVLMCupEnv` in `spot_env.py` and make something similar.
 
 
 ## Mapping

--- a/predicators/spot_utils/perception/spot_cameras.py
+++ b/predicators/spot_utils/perception/spot_cameras.py
@@ -170,7 +170,6 @@ def capture_images_without_context(
         rgbd = RGBDImage(rgb_img, depth_img, rot, camera_name, depth_scale,
                          camera_model)
         rgbds[camera_name] = rgbd
-
     return rgbds
 
 

--- a/predicators/utils.py
+++ b/predicators/utils.py
@@ -2571,12 +2571,10 @@ def get_prompt_for_vlm_state_labelling(
             if "spot" in CFG.env:  # pragma: no cover
                 # For spot envs, we need to label each of the images with
                 # "before" and "after".
-                prev_img_pil = PIL.Image.fromarray(prev_img)  # type: ignore
-                curr_img_pil = PIL.Image.fromarray(curr_img)  # type: ignore
-                draw_prev = ImageDraw.Draw(prev_img_pil)
-                prev_img_shape = prev_img_pil.size[:2]
-                draw_curr = ImageDraw.Draw(curr_img_pil)
-                curr_img_shape = curr_img_pil.size[:2]
+                draw_prev = ImageDraw.Draw(prev_img)
+                prev_img_shape = prev_img.size[:2]
+                draw_curr = ImageDraw.Draw(curr_img)
+                curr_img_shape = curr_img.size[:2]
                 font = get_scaled_default_font(draw_prev, 4)
                 prev_img_font_loc = (prev_img_shape[0] * 0.9,
                                      prev_img_shape[1] * 0.9)
@@ -2586,7 +2584,7 @@ def get_prompt_for_vlm_state_labelling(
                                          "Before", font)
                 _ = add_text_to_draw_img(draw_curr, curr_img_font_loc, "After",
                                          font)
-            curr_prompt_imgs.extend([prev_img_pil, curr_img_pil])
+            curr_prompt_imgs.extend([prev_img, curr_img])
 
         if CFG.vlm_include_cropped_images:
             if CFG.env in ["burger", "burger_no_move"]:  # pragma: no cover
@@ -2652,10 +2650,8 @@ def query_vlm_for_atom_vals(
     # Query VLM.
     if vlm is None:
         vlm = create_vlm_by_name(CFG.vlm_model_name)  # pragma: no cover.
-    vlm_input_imgs = \
-        [PIL.Image.fromarray(img_arr) for img_arr in imgs] # type: ignore
     vlm_output = vlm.sample_completions(vlm_query_str,
-                                        vlm_input_imgs,
+                                        imgs,
                                         0.0,
                                         seed=CFG.seed,
                                         num_completions=1)

--- a/predicators/utils.py
+++ b/predicators/utils.py
@@ -2576,10 +2576,10 @@ def get_prompt_for_vlm_state_labelling(
                 draw_curr = ImageDraw.Draw(curr_img)
                 curr_img_shape = curr_img.size[:2]
                 font = get_scaled_default_font(draw_prev, 4)
-                prev_img_font_loc = (prev_img_shape[0] * 0.9,
-                                     prev_img_shape[1] * 0.9)
-                curr_img_font_loc = (curr_img_shape[0] * 0.9,
-                                     curr_img_shape[1] * 0.9)
+                prev_img_font_loc = (int(prev_img_shape[0] * 0.9),
+                                     int(prev_img_shape[1] * 0.9))
+                curr_img_font_loc = (int(curr_img_shape[0] * 0.9),
+                                     int(curr_img_shape[1] * 0.9))
                 _ = add_text_to_draw_img(draw_prev, prev_img_font_loc,
                                          "Before", font)
                 _ = add_text_to_draw_img(draw_curr, curr_img_font_loc, "After",

--- a/predicators/utils.py
+++ b/predicators/utils.py
@@ -2571,8 +2571,8 @@ def get_prompt_for_vlm_state_labelling(
             if "spot" in CFG.env:  # pragma: no cover
                 # For spot envs, we need to label each of the images with
                 # "before" and "after".
-                prev_img_pil = PIL.Image.fromarray(prev_img)
-                curr_img_pil = PIL.Image.fromarray(curr_img)
+                prev_img_pil = PIL.Image.fromarray(prev_img)  # type: ignore
+                curr_img_pil = PIL.Image.fromarray(curr_img)  # type: ignore
                 draw_prev = ImageDraw.Draw(prev_img_pil)
                 prev_img_shape = prev_img_pil.size[:2]
                 draw_curr = ImageDraw.Draw(curr_img_pil)
@@ -2586,9 +2586,7 @@ def get_prompt_for_vlm_state_labelling(
                                          "Before", font)
                 _ = add_text_to_draw_img(draw_curr, curr_img_font_loc, "After",
                                          font)
-            curr_prompt_imgs.extend(
-                [np.array(prev_img_pil),
-                 np.array(curr_img_pil)])
+            curr_prompt_imgs.extend([prev_img_pil, curr_img_pil])
 
         if CFG.vlm_include_cropped_images:
             if CFG.env in ["burger", "burger_no_move"]:  # pragma: no cover

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -6,6 +6,7 @@ from typing import Type as TypingType
 
 import matplotlib.pyplot as plt
 import numpy as np
+import PIL.Image
 import pytest
 from gym.spaces import Box
 
@@ -1128,7 +1129,7 @@ def test_abstract():
                             lambda o: "is_fishy")
     vlm_state = state.copy()
     vlm_state.simulator_state = {
-        "images": [np.zeros((30, 30, 3), dtype=np.uint8)]
+        "images": [PIL.Image.fromarray(np.zeros((30, 30, 3), dtype=np.uint8))]
     }
     vlm_atoms_set = utils.abstract(vlm_state, [vlm_pred], _DummyVLM())
     assert len(vlm_atoms_set) == 1


### PR DESCRIPTION
This PR enables us to run a simple command to solve a real-world task that uses VLM predicates as well as an execution monitor for replanning! The main changes required to get this to work were:

- Enabling all cameras instead of only front-left
- Removing assumption in VLM-atom-labelling query that there is only one image per timestep
- Explicitly using set-of-marks prompting to include "Before" and "After" in each of the images being sent for atom labelling

Command:
```
python predicators/main.py --env spot_vlm_cup_table_env --approach "spot_wrapper[oracle]" --seed 0 --num_train_tasks 0 --num_test_tasks 1 --spot_robot_ip 192.168.80.3 --perceiver spot_minimal_perceiver --bilevel_plan_without_sim True --vlm_test_time_atom_label_prompt_type img_option_diffs_label_history --vlm_model_name gpt-4o --execution_monitor expected_atoms
```

(We also update the Spot README with instructions for running this command and creating similar environments)